### PR TITLE
Feat: 인증 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,42 +1,60 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.4.3'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.4.3'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.gdg'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.7.0'
+    // Spring Boot Starter Dependencies
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    // Security & JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+    // Database & Redis
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+
+    // Test Dependencies
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // etc
+    implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.7.0'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/com/gdg/Todak/common/config/WebConfig.java
+++ b/src/main/java/com/gdg/Todak/common/config/WebConfig.java
@@ -1,14 +1,45 @@
 package com.gdg.Todak.common.config;
 
+import com.gdg.Todak.member.Interceptor.LoginCheckInterceptor;
+import com.gdg.Todak.member.resolver.LoginMemberArgumentResolver;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.List;
+
+@RequiredArgsConstructor
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
+    private final LoginCheckInterceptor loginCheckInterceptor;
+    private final LoginMemberArgumentResolver loginMemberArgumentResolver;
+
+    List<String> whiteList = List.of(
+            "/api/users/check-username",
+            "/api/users/signup",
+            "/api/users/login",
+            "/api/users/logout"
+    );
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(loginCheckInterceptor)
+                .order(1)
+                .addPathPatterns("/**")
+                .excludePathPatterns(whiteList);
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginMemberArgumentResolver);
+    }
 
     @Bean
     public CorsFilter corsFilter() {

--- a/src/main/java/com/gdg/Todak/member/Interceptor/LoginCheckInterceptor.java
+++ b/src/main/java/com/gdg/Todak/member/Interceptor/LoginCheckInterceptor.java
@@ -1,0 +1,84 @@
+package com.gdg.Todak.member.Interceptor;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gdg.Todak.member.domain.AuthenticateUser;
+import com.gdg.Todak.member.domain.Member;
+import com.gdg.Todak.member.domain.Role;
+import com.gdg.Todak.member.exception.UnauthorizedException;
+import com.gdg.Todak.member.repository.MemberRepository;
+import com.gdg.Todak.member.util.JwtProvider;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.util.Optional;
+import java.util.Set;
+
+@RequiredArgsConstructor
+@Component
+public class LoginCheckInterceptor implements HandlerInterceptor {
+
+    public static final String BEARER = "Bearer ";
+
+    private final JwtProvider jwtProvider;
+    private final ObjectMapper objectMapper;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
+                             Object handler) {
+
+        String header = request.getHeader("Authorization");
+
+        if (isNotValidToken(header)) {
+            throw new UnauthorizedException("토큰이 없거나, 헤더 형식에 맞지 않습니다.");
+        }
+
+        String token = getToken(header);
+        Claims claims = jwtProvider.getClaims(token);
+        if (claims == null) {
+            throw new UnauthorizedException("유효하지 않은 토큰입니다.");
+        }
+
+        AuthenticateUser authenticateUser = getAuthenticateUser(claims);
+
+        String username = authenticateUser.getUsername();
+        Set<Role> roles = authenticateUser.getRoles();
+
+        Optional<Member> findMember = memberRepository.findByUsername(username);
+        if (findMember.isEmpty()) {
+            throw new UnauthorizedException("해당 사용자가 존재하지 않습니다.");
+        }
+
+        if (invalidMemberRoles(findMember, roles)) {
+            throw new UnauthorizedException("사용자의 권한이 올바르지 않습니다.");
+        }
+
+        return true;
+    }
+
+    private static boolean isNotValidToken(String header) {
+        return header == null || !header.startsWith(BEARER);
+    }
+
+    private static String getToken(String header) {
+        return header.substring(7);
+    }
+
+    private static boolean invalidMemberRoles(Optional<Member> findMember, Set<Role> roles) {
+        return !findMember.get().getRoles().containsAll(roles);
+    }
+
+    private AuthenticateUser getAuthenticateUser(Claims claims) {
+        try {
+            String json = claims.get(jwtProvider.AUTHENTICATE_USER).toString();
+            return objectMapper.readValue(json, AuthenticateUser.class);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("토큰에서 사용자 정보를 변환할 수 없습니다.", e);
+        }
+    }
+}

--- a/src/main/java/com/gdg/Todak/member/config/RedisConfig.java
+++ b/src/main/java/com/gdg/Todak/member/config/RedisConfig.java
@@ -1,0 +1,34 @@
+package com.gdg.Todak.member.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${secrets.REDIS_HOST}")
+    private String host;
+    @Value("${secrets.REDIS_PORT}")
+    private int port;
+
+    @Bean
+    LettuceConnectionFactory connectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(host);
+        redisStandaloneConfiguration.setPort(port);
+        LettuceConnectionFactory lettuceConnectionFactory = new LettuceConnectionFactory(
+                redisStandaloneConfiguration);
+        return lettuceConnectionFactory;
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory());
+        return template;
+    }
+}

--- a/src/main/java/com/gdg/Todak/member/controller/AuthController.java
+++ b/src/main/java/com/gdg/Todak/member/controller/AuthController.java
@@ -1,0 +1,25 @@
+package com.gdg.Todak.member.controller;
+
+import com.gdg.Todak.common.domain.ApiResponse;
+import com.gdg.Todak.member.controller.request.UpdateAccessTokenRequest;
+import com.gdg.Todak.member.domain.Jwt;
+import com.gdg.Todak.member.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+@RestController
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/refresh")
+    public ApiResponse<Jwt> updateRefreshToken(@RequestBody UpdateAccessTokenRequest request) {
+        return ApiResponse.ok(authService.updateAccessToken(request.toServiceRequest()));
+    }
+
+}

--- a/src/main/java/com/gdg/Todak/member/controller/MemberController.java
+++ b/src/main/java/com/gdg/Todak/member/controller/MemberController.java
@@ -1,0 +1,56 @@
+package com.gdg.Todak.member.controller;
+
+import com.gdg.Todak.common.domain.ApiResponse;
+import com.gdg.Todak.member.controller.request.CheckUsernameRequest;
+import com.gdg.Todak.member.controller.request.LoginRequest;
+import com.gdg.Todak.member.controller.request.LogoutRequest;
+import com.gdg.Todak.member.controller.request.SignupRequest;
+import com.gdg.Todak.member.domain.AuthenticateUser;
+import com.gdg.Todak.member.domain.Jwt;
+import com.gdg.Todak.member.resolver.Login;
+import com.gdg.Todak.member.service.MemberService;
+import com.gdg.Todak.member.service.response.CheckUsernameServiceResponse;
+import com.gdg.Todak.member.service.response.LogoutResponse;
+import com.gdg.Todak.member.service.response.MeResponse;
+import com.gdg.Todak.member.service.response.MemberResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+@RestController
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/check-username")
+    public ApiResponse<CheckUsernameServiceResponse> checkUsername(
+            @RequestBody CheckUsernameRequest request) {
+        return ApiResponse.ok(memberService.checkUsername(request.toServiceRequest()));
+    }
+
+    @PostMapping("/signup")
+    public ApiResponse<MemberResponse> signup(@RequestBody @Validated SignupRequest request) {
+        return ApiResponse.ok(memberService.signup(request.toServiceRequest()));
+    }
+
+    @PostMapping("/login")
+    public ApiResponse<Jwt> login(@RequestBody LoginRequest request) {
+        return ApiResponse.ok(memberService.login(request.toServiceRequest()));
+    }
+
+    @PostMapping("/logout")
+    public ApiResponse<LogoutResponse> logout(@Login AuthenticateUser user,
+                                              @RequestBody LogoutRequest request) {
+        return ApiResponse.ok(memberService.logout(user, request.toServiceRequest()));
+    }
+
+    @PostMapping("/me")
+    public ApiResponse<MeResponse> me(@Login AuthenticateUser user) {
+        return ApiResponse.ok(memberService.me(user));
+    }
+}

--- a/src/main/java/com/gdg/Todak/member/controller/advice/MemberControllerAdvice.java
+++ b/src/main/java/com/gdg/Todak/member/controller/advice/MemberControllerAdvice.java
@@ -1,0 +1,41 @@
+package com.gdg.Todak.member.controller.advice;
+
+import com.gdg.Todak.common.domain.ApiResponse;
+import com.gdg.Todak.member.exception.EncryptionException;
+import com.gdg.Todak.member.exception.UnauthorizedException;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class MemberControllerAdvice {
+
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    @ExceptionHandler(UnauthorizedException.class)
+    public ApiResponse<Exception> loginFailed(UnauthorizedException e) {
+        return ApiResponse.of(
+                HttpStatus.UNAUTHORIZED,
+                e.getMessage()
+        );
+    }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(EncryptionException.class)
+    public ApiResponse<Exception> encryptionFailed(EncryptionException e) {
+        return ApiResponse.of(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                e.getMessage()
+        );
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(BindException.class)
+    public ApiResponse<Object> bindException(BindException e) {
+        return ApiResponse.of(
+                HttpStatus.BAD_REQUEST,
+                e.getBindingResult().getAllErrors().get(0).getDefaultMessage()
+        );
+    }
+}

--- a/src/main/java/com/gdg/Todak/member/controller/request/CheckUsernameRequest.java
+++ b/src/main/java/com/gdg/Todak/member/controller/request/CheckUsernameRequest.java
@@ -1,0 +1,24 @@
+package com.gdg.Todak.member.controller.request;
+
+import com.gdg.Todak.member.service.request.CheckUsernameServiceRequest;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CheckUsernameRequest {
+
+    private String username;
+
+    @Builder
+    public CheckUsernameRequest(String username) {
+        this.username = username;
+    }
+
+    public CheckUsernameServiceRequest toServiceRequest() {
+        return CheckUsernameServiceRequest.builder()
+                .username(username)
+                .build();
+    }
+}

--- a/src/main/java/com/gdg/Todak/member/controller/request/LoginRequest.java
+++ b/src/main/java/com/gdg/Todak/member/controller/request/LoginRequest.java
@@ -1,0 +1,16 @@
+package com.gdg.Todak.member.controller.request;
+
+import com.gdg.Todak.member.service.request.LoginServiceRequest;
+
+public record LoginRequest(
+        String username,
+        String password
+) {
+
+    public LoginServiceRequest toServiceRequest() {
+        return LoginServiceRequest.builder()
+                .username(username)
+                .password(password)
+                .build();
+    }
+}

--- a/src/main/java/com/gdg/Todak/member/controller/request/LogoutRequest.java
+++ b/src/main/java/com/gdg/Todak/member/controller/request/LogoutRequest.java
@@ -1,0 +1,24 @@
+package com.gdg.Todak.member.controller.request;
+
+import com.gdg.Todak.member.service.request.LogoutServiceRequest;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LogoutRequest {
+
+    private String refreshToken;
+
+    @Builder
+    public LogoutRequest(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public LogoutServiceRequest toServiceRequest() {
+        return LogoutServiceRequest.builder()
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/com/gdg/Todak/member/controller/request/SignupRequest.java
+++ b/src/main/java/com/gdg/Todak/member/controller/request/SignupRequest.java
@@ -1,0 +1,33 @@
+package com.gdg.Todak.member.controller.request;
+
+import com.gdg.Todak.member.service.request.SignupServiceRequest;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SignupRequest {
+
+    @NotBlank
+    @Size(min = 3, max = 20)
+    private String username;
+    @NotBlank
+    @Size(min = 8, max = 16)
+    private String password;
+
+    @Builder
+    public SignupRequest(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    public SignupServiceRequest toServiceRequest() {
+        return SignupServiceRequest.builder()
+                .username(username)
+                .password(password)
+                .build();
+    }
+}

--- a/src/main/java/com/gdg/Todak/member/controller/request/UpdateAccessTokenRequest.java
+++ b/src/main/java/com/gdg/Todak/member/controller/request/UpdateAccessTokenRequest.java
@@ -1,0 +1,25 @@
+package com.gdg.Todak.member.controller.request;
+
+
+import com.gdg.Todak.member.service.request.UpdateAccessTokenServiceRequest;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateAccessTokenRequest {
+
+    private String refreshToken;
+
+    @Builder
+    public UpdateAccessTokenRequest(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public UpdateAccessTokenServiceRequest toServiceRequest() {
+        return UpdateAccessTokenServiceRequest.builder()
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/com/gdg/Todak/member/domain/AuthenticateUser.java
+++ b/src/main/java/com/gdg/Todak/member/domain/AuthenticateUser.java
@@ -1,0 +1,21 @@
+package com.gdg.Todak.member.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Set;
+
+@Getter
+@NoArgsConstructor
+public class AuthenticateUser {
+
+    private String username;
+    private Set<Role> roles;
+
+    @Builder
+    public AuthenticateUser(String username, Set<Role> roles) {
+        this.username = username;
+        this.roles = roles;
+    }
+}

--- a/src/main/java/com/gdg/Todak/member/domain/Jwt.java
+++ b/src/main/java/com/gdg/Todak/member/domain/Jwt.java
@@ -1,0 +1,24 @@
+package com.gdg.Todak.member.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Jwt {
+
+    private String accessToken;
+    private String refreshToken;
+
+    @Builder
+    public Jwt(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+
+    public static Jwt of(String accessToken, String refreshToken) {
+        return Jwt.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/com/gdg/Todak/member/domain/Member.java
+++ b/src/main/java/com/gdg/Todak/member/domain/Member.java
@@ -1,0 +1,58 @@
+package com.gdg.Todak.member.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String username;
+
+    private String password;
+
+    private String imageUrl;
+
+    private String salt;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+    private Set<MemberRole> memberRoles = new HashSet<>();
+
+    @Builder
+    public Member(String username, String password, String imageUrl, String salt) {
+        this.username = username;
+        this.password = password;
+        this.imageUrl = imageUrl;
+        this.salt = salt;
+    }
+
+    public static Member of(String username, String password, String imageUrl, String salt) {
+        return Member.builder()
+                .username(username)
+                .password(password)
+                .imageUrl(imageUrl)
+                .salt(salt)
+                .build();
+    }
+
+    public void addRole(MemberRole memberRole) {
+        memberRoles.add(memberRole);
+    }
+
+    public Set<Role> getRoles() {
+        return memberRoles.stream()
+                .map(MemberRole::getRole).collect(Collectors.toSet());
+    }
+}

--- a/src/main/java/com/gdg/Todak/member/domain/MemberRole.java
+++ b/src/main/java/com/gdg/Todak/member/domain/MemberRole.java
@@ -1,0 +1,35 @@
+package com.gdg.Todak.member.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class MemberRole {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+    private Role role;
+
+    @Builder
+    public MemberRole(Member member, Role role) {
+        this.member = member;
+        this.role = role;
+    }
+
+    public static MemberRole of(Role role, Member member) {
+        return MemberRole.builder()
+                .role(role)
+                .member(member)
+                .build();
+    }
+}

--- a/src/main/java/com/gdg/Todak/member/domain/Role.java
+++ b/src/main/java/com/gdg/Todak/member/domain/Role.java
@@ -1,0 +1,30 @@
+package com.gdg.Todak.member.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum Role {
+    USER("USER"),
+    ADMIN("ADMIN");
+
+    private String value;
+
+    Role(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static Role fromValue(String value) {
+        for (Role role : Role.values()) {
+            if (role.value.equals(value)) {
+                return role;
+            }
+        }
+        throw new IllegalArgumentException(value);
+    }
+}

--- a/src/main/java/com/gdg/Todak/member/exception/EncryptionException.java
+++ b/src/main/java/com/gdg/Todak/member/exception/EncryptionException.java
@@ -1,0 +1,8 @@
+package com.gdg.Todak.member.exception;
+
+public class EncryptionException extends RuntimeException {
+
+    public EncryptionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/gdg/Todak/member/exception/MemberException.java
+++ b/src/main/java/com/gdg/Todak/member/exception/MemberException.java
@@ -1,0 +1,8 @@
+package com.gdg.Todak.member.exception;
+
+public class MemberException extends RuntimeException {
+
+    public MemberException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/gdg/Todak/member/exception/UnauthorizedException.java
+++ b/src/main/java/com/gdg/Todak/member/exception/UnauthorizedException.java
@@ -1,0 +1,8 @@
+package com.gdg.Todak.member.exception;
+
+public class UnauthorizedException extends RuntimeException {
+
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/gdg/Todak/member/repository/MemberRepository.java
+++ b/src/main/java/com/gdg/Todak/member/repository/MemberRepository.java
@@ -1,0 +1,13 @@
+package com.gdg.Todak.member.repository;
+
+import com.gdg.Todak.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByUsername(String username);
+}

--- a/src/main/java/com/gdg/Todak/member/repository/MemberRoleRepository.java
+++ b/src/main/java/com/gdg/Todak/member/repository/MemberRoleRepository.java
@@ -1,0 +1,8 @@
+package com.gdg.Todak.member.repository;
+
+import com.gdg.Todak.member.domain.MemberRole;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRoleRepository extends JpaRepository<MemberRole, Long> {
+
+}

--- a/src/main/java/com/gdg/Todak/member/resolver/Login.java
+++ b/src/main/java/com/gdg/Todak/member/resolver/Login.java
@@ -1,0 +1,12 @@
+package com.gdg.Todak.member.resolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Login {
+
+}

--- a/src/main/java/com/gdg/Todak/member/resolver/LoginMemberArgumentResolver.java
+++ b/src/main/java/com/gdg/Todak/member/resolver/LoginMemberArgumentResolver.java
@@ -1,0 +1,53 @@
+package com.gdg.Todak.member.resolver;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gdg.Todak.member.domain.AuthenticateUser;
+import com.gdg.Todak.member.util.JwtProvider;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@RequiredArgsConstructor
+@Component
+public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtProvider jwtProvider;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean hasLoginAnnotation = parameter.hasParameterAnnotation(Login.class);
+
+        boolean hasAuthenticateUserType = AuthenticateUser.class.isAssignableFrom(
+                parameter.getParameterType());
+
+        return hasLoginAnnotation && hasAuthenticateUserType;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        String header = request.getHeader("Authorization");
+        if (header == null || !header.startsWith("Bearer ")) {
+            return null;
+        }
+
+        String token = header.substring(7); // accessToken
+        Claims claims = jwtProvider.getClaims(token);
+        if (claims == null) {
+            return null;
+        }
+
+        String json = claims.get(jwtProvider.AUTHENTICATE_USER).toString();
+        AuthenticateUser authenticateUser = objectMapper.readValue(json, AuthenticateUser.class);
+
+        return authenticateUser;
+    }
+}

--- a/src/main/java/com/gdg/Todak/member/service/AuthService.java
+++ b/src/main/java/com/gdg/Todak/member/service/AuthService.java
@@ -1,0 +1,56 @@
+package com.gdg.Todak.member.service;
+
+import com.gdg.Todak.member.domain.Jwt;
+import com.gdg.Todak.member.domain.Member;
+import com.gdg.Todak.member.exception.UnauthorizedException;
+import com.gdg.Todak.member.repository.MemberRepository;
+import com.gdg.Todak.member.service.request.UpdateAccessTokenServiceRequest;
+import com.gdg.Todak.member.util.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class AuthService {
+
+    private final JwtProvider jwtProvider;
+    private final RedisTemplate redisTemplate;
+    private final MemberRepository memberRepository;
+
+    public Jwt updateAccessToken(UpdateAccessTokenServiceRequest request) {
+        String refreshToken = request.getRefreshToken();
+
+        Long memberId = getMemberId(refreshToken);
+
+        if (memberId == null) {
+            throw new UnauthorizedException("리프레시 토큰이 만료되었습니다.");
+        }
+
+        Member member = getMemberById(memberId);
+
+        String accessToken = createNewAccessToken(member);
+
+        return Jwt.of(accessToken, refreshToken);
+    }
+
+    private Long getMemberId(String refreshToken) {
+        return (Long) redisTemplate.opsForValue().get(refreshToken);
+    }
+
+    private Member getMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new UnauthorizedException("멤버가 존재하지 않습니다."));
+    }
+
+    private String createNewAccessToken(Member member) {
+        Map<String, Object> claims = jwtProvider.createClaims(member, member.getRoles());
+
+        String accessToken = jwtProvider.createAccessToken(claims);
+        return accessToken;
+    }
+}

--- a/src/main/java/com/gdg/Todak/member/service/MemberService.java
+++ b/src/main/java/com/gdg/Todak/member/service/MemberService.java
@@ -1,0 +1,109 @@
+package com.gdg.Todak.member.service;
+
+import com.gdg.Todak.member.domain.*;
+import com.gdg.Todak.member.exception.UnauthorizedException;
+import com.gdg.Todak.member.repository.MemberRepository;
+import com.gdg.Todak.member.repository.MemberRoleRepository;
+import com.gdg.Todak.member.service.request.CheckUsernameServiceRequest;
+import com.gdg.Todak.member.service.request.LoginServiceRequest;
+import com.gdg.Todak.member.service.request.LogoutServiceRequest;
+import com.gdg.Todak.member.service.request.SignupServiceRequest;
+import com.gdg.Todak.member.service.response.CheckUsernameServiceResponse;
+import com.gdg.Todak.member.service.response.LogoutResponse;
+import com.gdg.Todak.member.service.response.MeResponse;
+import com.gdg.Todak.member.service.response.MemberResponse;
+import com.gdg.Todak.member.util.JwtProvider;
+import com.gdg.Todak.member.util.PasswordEncoder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final MemberRoleRepository memberRoleRepository;
+    private final JwtProvider jwtProvider;
+    private final RedisTemplate redisTemplate;
+
+    public CheckUsernameServiceResponse checkUsername(CheckUsernameServiceRequest serviceRequest) {
+        Optional<Member> findMember = memberRepository.findByUsername(serviceRequest.getUsername());
+        return CheckUsernameServiceResponse.of(findMember.isPresent());
+    }
+
+    @Transactional
+    public MemberResponse signup(SignupServiceRequest request) {
+
+        String salt = PasswordEncoder.getSalt();
+
+        String encodedPassword = PasswordEncoder.getEncodedPassword(salt, request.getPassword());
+
+        Member member = memberRepository.save(
+                Member.of(request.getUsername(), encodedPassword, null, salt));
+
+        MemberRole role = MemberRole.of(Role.USER, member);
+        member.addRole(role);
+
+        memberRoleRepository.save(role);
+
+        return MemberResponse.of(member.getUsername());
+    }
+
+    public Jwt login(LoginServiceRequest request) {
+
+        Member member = findMember(request.getUsername());
+
+        checkPassword(request, member);
+
+        Set<Role> roles = member.getRoles();
+
+        Map<String, Object> claims = jwtProvider.createClaims(member, roles);
+
+        String accessToken = jwtProvider.createAccessToken(claims);
+        String refreshToken = jwtProvider.createRefreshToken();
+
+        saveRefreshToken(refreshToken, member);
+
+        return Jwt.of(accessToken, refreshToken);
+    }
+
+    public LogoutResponse logout(AuthenticateUser user, LogoutServiceRequest serviceRequest) {
+        if (user != null) {
+            redisTemplate.delete(serviceRequest.getRefreshToken());
+        }
+
+        String message = "성공적으로 로그아웃 되었습니다.";
+
+        return LogoutResponse.of(message);
+    }
+
+    public MeResponse me(AuthenticateUser user) {
+        Member member = findMember(user.getUsername());
+        return MeResponse.of(member);
+    }
+
+    private Member findMember(String username) {
+        return memberRepository.findByUsername(username)
+                .orElseThrow(() -> new UnauthorizedException("멤버가 존재하지 않습니다."));
+    }
+
+    private static void checkPassword(LoginServiceRequest request, Member member) {
+        String encodedPassword = PasswordEncoder.getEncodedPassword(member.getSalt(),
+                request.getPassword());
+        if (!encodedPassword.equals(member.getPassword())) {
+            throw new UnauthorizedException("비밀번호가 올바르지 않습니다.");
+        }
+    }
+
+    private void saveRefreshToken(String refreshToken, Member member) {
+        redisTemplate.opsForValue().set(refreshToken, member.getId(), 14, TimeUnit.DAYS);
+    }
+}

--- a/src/main/java/com/gdg/Todak/member/service/request/CheckUsernameServiceRequest.java
+++ b/src/main/java/com/gdg/Todak/member/service/request/CheckUsernameServiceRequest.java
@@ -1,0 +1,17 @@
+package com.gdg.Todak.member.service.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CheckUsernameServiceRequest {
+
+    private String username;
+
+    @Builder
+    public CheckUsernameServiceRequest(String username) {
+        this.username = username;
+    }
+}

--- a/src/main/java/com/gdg/Todak/member/service/request/LoginServiceRequest.java
+++ b/src/main/java/com/gdg/Todak/member/service/request/LoginServiceRequest.java
@@ -1,0 +1,19 @@
+package com.gdg.Todak.member.service.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginServiceRequest {
+
+    private String username;
+    private String password;
+
+    @Builder
+    public LoginServiceRequest(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+}

--- a/src/main/java/com/gdg/Todak/member/service/request/LogoutServiceRequest.java
+++ b/src/main/java/com/gdg/Todak/member/service/request/LogoutServiceRequest.java
@@ -1,0 +1,17 @@
+package com.gdg.Todak.member.service.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LogoutServiceRequest {
+
+    private String refreshToken;
+
+    @Builder
+    public LogoutServiceRequest(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/gdg/Todak/member/service/request/SignupServiceRequest.java
+++ b/src/main/java/com/gdg/Todak/member/service/request/SignupServiceRequest.java
@@ -1,0 +1,19 @@
+package com.gdg.Todak.member.service.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SignupServiceRequest {
+
+    private String username;
+    private String password;
+
+    @Builder
+    public SignupServiceRequest(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+}

--- a/src/main/java/com/gdg/Todak/member/service/request/UpdateAccessTokenServiceRequest.java
+++ b/src/main/java/com/gdg/Todak/member/service/request/UpdateAccessTokenServiceRequest.java
@@ -1,0 +1,17 @@
+package com.gdg.Todak.member.service.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateAccessTokenServiceRequest {
+
+    private String refreshToken;
+
+    @Builder
+    public UpdateAccessTokenServiceRequest(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/gdg/Todak/member/service/response/CheckUsernameServiceResponse.java
+++ b/src/main/java/com/gdg/Todak/member/service/response/CheckUsernameServiceResponse.java
@@ -1,0 +1,23 @@
+package com.gdg.Todak.member.service.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CheckUsernameServiceResponse {
+
+    private Boolean exists;
+
+    @Builder
+    public CheckUsernameServiceResponse(Boolean exists) {
+        this.exists = exists;
+    }
+
+    public static CheckUsernameServiceResponse of(Boolean exists) {
+        return CheckUsernameServiceResponse.builder()
+                .exists(exists)
+                .build();
+    }
+}

--- a/src/main/java/com/gdg/Todak/member/service/response/LogoutResponse.java
+++ b/src/main/java/com/gdg/Todak/member/service/response/LogoutResponse.java
@@ -1,0 +1,23 @@
+package com.gdg.Todak.member.service.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LogoutResponse {
+
+    private String message;
+
+    @Builder
+    public LogoutResponse(String message) {
+        this.message = message;
+    }
+
+    public static LogoutResponse of(String message) {
+        return LogoutResponse.builder()
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/com/gdg/Todak/member/service/response/MeResponse.java
+++ b/src/main/java/com/gdg/Todak/member/service/response/MeResponse.java
@@ -1,0 +1,27 @@
+package com.gdg.Todak.member.service.response;
+
+import com.gdg.Todak.member.domain.Member;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MeResponse {
+
+    private String username;
+    private String imageUrl;
+
+    @Builder
+    public MeResponse(String username, String imageUrl) {
+        this.username = username;
+        this.imageUrl = imageUrl;
+    }
+
+    public static MeResponse of(Member member) {
+        return MeResponse.builder()
+                .username(member.getUsername())
+                .imageUrl(member.getImageUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/gdg/Todak/member/service/response/MemberResponse.java
+++ b/src/main/java/com/gdg/Todak/member/service/response/MemberResponse.java
@@ -1,0 +1,23 @@
+package com.gdg.Todak.member.service.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MemberResponse {
+
+    private String username;
+
+    @Builder
+    public MemberResponse(String username) {
+        this.username = username;
+    }
+
+    public static MemberResponse of(String username) {
+        return MemberResponse.builder()
+                .username(username)
+                .build();
+    }
+}

--- a/src/main/java/com/gdg/Todak/member/util/JwtProvider.java
+++ b/src/main/java/com/gdg/Todak/member/util/JwtProvider.java
@@ -1,0 +1,90 @@
+package com.gdg.Todak.member.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gdg.Todak.member.domain.AuthenticateUser;
+import com.gdg.Todak.member.domain.Member;
+import com.gdg.Todak.member.domain.Role;
+import com.gdg.Todak.member.exception.UnauthorizedException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.io.IOException;
+import java.security.Key;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class JwtProvider {
+
+    private final ObjectMapper objectMapper;
+
+    @Value("${secrets.SECRET_KEY}")
+    private String secretKey;
+
+    private byte[] secretKeyBytes;
+    private Key key;
+
+    public static final String AUTHENTICATE_USER = "authenticateUser";
+
+    @PostConstruct
+    public void init() {
+        secretKeyBytes = secretKey.getBytes();
+        key = Keys.hmacShaKeyFor(secretKeyBytes);
+    }
+
+    public String createToken(Map<String, Object> claims, Date expireDate) {
+        return Jwts.builder()
+                .claims(claims)
+                .expiration(expireDate)
+                .signWith(key)
+                .compact();
+    }
+
+    public Claims getClaims(String token) {
+        return Jwts.parser()
+                .verifyWith((SecretKey) key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    public String createRefreshToken() {
+        return createToken(new HashMap<>(), getExpireDateRefreshToken());
+    }
+
+    public Map<String, Object> createClaims(Member member, Set<Role> roles) {
+        Map<String, Object> claims = new HashMap<>();
+        AuthenticateUser authenticateUser = new AuthenticateUser(member.getUsername(), roles);
+
+        try {
+            String authenticateUserJson = objectMapper.writeValueAsString(authenticateUser);
+            claims.put(AUTHENTICATE_USER, authenticateUserJson);
+        } catch (IOException e) {
+            throw new UnauthorizedException(e.getMessage());
+        }
+        return claims;
+    }
+
+    public String createAccessToken(Map<String, Object> claims) {
+        return createToken(claims, getExpireDateAccessToken());
+    }
+
+    public Date getExpireDateAccessToken() {
+        long expireTimeMils = 1000 * 60 * 30;
+        return new Date(System.currentTimeMillis() + expireTimeMils);
+    }
+
+    public Date getExpireDateRefreshToken() {
+        long expireTimeMils = 1000L * 60 * 60 * 24 * 14;
+        return new Date(System.currentTimeMillis() + expireTimeMils);
+    }
+}

--- a/src/main/java/com/gdg/Todak/member/util/PasswordEncoder.java
+++ b/src/main/java/com/gdg/Todak/member/util/PasswordEncoder.java
@@ -1,0 +1,31 @@
+package com.gdg.Todak.member.util;
+
+import com.gdg.Todak.member.exception.EncryptionException;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+public class PasswordEncoder {
+
+    public static String getSalt() {
+        byte[] salt = new byte[16];
+        new SecureRandom().nextBytes(salt);
+        return Base64.getEncoder().encodeToString(salt);
+    }
+
+    public static String getEncodedPassword(String salt, String rawPassword) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] encodedPassword = md.digest((salt + rawPassword).getBytes());
+            StringBuilder sb = new StringBuilder();
+            for (byte b : encodedPassword) {
+                sb.append(String.format("%02x", b));
+            }
+            return salt + sb;
+        } catch (NoSuchAlgorithmException e) {
+            throw new EncryptionException("비밀번호 암호화 중에 문제가 발생했습니다.", e);
+        }
+    }
+}

--- a/src/test/java/com/gdg/Todak/member/Interceptor/LoginCheckInterceptorTest.java
+++ b/src/test/java/com/gdg/Todak/member/Interceptor/LoginCheckInterceptorTest.java
@@ -1,0 +1,93 @@
+package com.gdg.Todak.member.Interceptor;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gdg.Todak.member.domain.AuthenticateUser;
+import com.gdg.Todak.member.domain.Member;
+import com.gdg.Todak.member.domain.MemberRole;
+import com.gdg.Todak.member.domain.Role;
+import com.gdg.Todak.member.repository.MemberRepository;
+import com.gdg.Todak.member.util.JwtProvider;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LoginCheckInterceptorTest {
+
+    @Mock
+    HttpServletRequest request;
+    @Mock
+    HttpServletResponse response;
+
+    @Mock
+    JwtProvider jwtProvider;
+
+    @Mock
+    ObjectMapper objectMapper;
+
+    @Mock
+    MemberRepository memberRepository;
+
+    @InjectMocks
+    LoginCheckInterceptor loginCheckInterceptor;
+
+    @DisplayName("LoginCheckInterceptor에 의해 요청이 검사된다.")
+    @Test
+    void LoginCheckInterceptorTest() throws JsonProcessingException {
+        // given
+        String accessToken = "Bearer abc";
+
+        String username = "username";
+        Set<Role> roles = Set.of(Role.USER);
+
+        Member member = Member.builder()
+                .username(username)
+                .password("password")
+                .build();
+
+        member.addRole(new MemberRole(member, Role.USER));
+
+        AuthenticateUser user = AuthenticateUser.builder()
+                .username(username)
+                .roles(roles)
+                .build();
+
+        Map<String, Object> claimsMap = new HashMap<>();
+        claimsMap.put("authenticateUser", user);
+
+        Claims mockClaims = Jwts.claims(claimsMap);
+
+        when(request.getHeader("Authorization")).thenReturn(accessToken);
+
+        when(jwtProvider.getClaims(any(String.class))).thenReturn(mockClaims);
+
+        when(objectMapper.readValue(any(String.class), eq(AuthenticateUser.class))).thenReturn(user);
+
+        when(memberRepository.findByUsername(username)).thenReturn(Optional.of(member));
+
+        // when
+        boolean result = loginCheckInterceptor.preHandle(request, response, null);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+}

--- a/src/test/java/com/gdg/Todak/member/config/RedisConfigTest.java
+++ b/src/test/java/com/gdg/Todak/member/config/RedisConfigTest.java
@@ -1,0 +1,58 @@
+package com.gdg.Todak.member.config;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class RedisConfigTest {
+
+    @Autowired
+    RedisTemplate redisTemplate;
+
+    Long memberId = 1L;
+    String refreshToken = "abcd";
+    String nonExistentRefreshToken = "ABCD";
+
+    @AfterEach
+    void tearDown() {
+        redisTemplate.delete(refreshToken);
+        redisTemplate.delete(nonExistentRefreshToken);
+    }
+
+    @DisplayName("레디스에 refreshToken을 key, memberId를 value로 저장 후 조회한다.")
+    @Test
+    void redisRetrieveTest() {
+        // given
+        redisTemplate.opsForValue().set(refreshToken, memberId, 7, TimeUnit.DAYS);
+
+        // when
+        Long findMemberId = (Long) redisTemplate.opsForValue().get(refreshToken);
+
+        // then
+        assertThat(findMemberId).isEqualTo(memberId);
+    }
+
+    @DisplayName("레디스에 존재하지 않는 key로 조회시 null이 반환된다.")
+    @Test
+    void redisRetrieveErrorTest() {
+        // given
+        Long memberId = 1L;
+        String refreshToken = "abcd";
+
+        redisTemplate.opsForValue().set(refreshToken, memberId, 7, TimeUnit.DAYS);
+
+        // when
+        Long findMemberId = (Long) redisTemplate.opsForValue().get(nonExistentRefreshToken);
+
+        // then
+        assertThat(findMemberId).isNull();
+    }
+}

--- a/src/test/java/com/gdg/Todak/member/controller/AuthControllerTest.java
+++ b/src/test/java/com/gdg/Todak/member/controller/AuthControllerTest.java
@@ -1,0 +1,49 @@
+package com.gdg.Todak.member.controller;
+
+import com.gdg.Todak.member.controller.request.UpdateAccessTokenRequest;
+import com.gdg.Todak.member.domain.Jwt;
+import com.gdg.Todak.member.service.request.UpdateAccessTokenServiceRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class AuthControllerTest extends ControllerTestSupport {
+
+    @DisplayName("유효한 리프레시 토큰으로 요청 시 새로운 액세스 토큰이 발급된다")
+    @Test
+    void updateRefreshTokenTest() throws Exception {
+        // given
+        String refreshToken = "refresh_token";
+
+        UpdateAccessTokenRequest request = UpdateAccessTokenRequest.builder()
+                .refreshToken(refreshToken)
+                .build();
+
+        Jwt jwt = Jwt.builder()
+                .accessToken("new_access_token")
+                .refreshToken(refreshToken)
+                .build();
+
+        // when
+        when(authService.updateAccessToken(any(UpdateAccessTokenServiceRequest.class))).thenReturn(jwt);
+
+        // then
+        mockMvc.perform(
+                        post("/api/auth/refresh")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.message").value("OK"));
+    }
+}

--- a/src/test/java/com/gdg/Todak/member/controller/ControllerTestSupport.java
+++ b/src/test/java/com/gdg/Todak/member/controller/ControllerTestSupport.java
@@ -1,0 +1,31 @@
+package com.gdg.Todak.member.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gdg.Todak.member.service.AuthService;
+import com.gdg.Todak.member.service.MemberService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = {
+        AuthController.class,
+        MemberController.class
+})
+@Import(TestWebConfig.class)
+public abstract class ControllerTestSupport {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockitoBean
+    MemberService memberService;
+
+    @MockitoBean
+    AuthService authService;
+}
+

--- a/src/test/java/com/gdg/Todak/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/gdg/Todak/member/controller/MemberControllerTest.java
@@ -1,0 +1,118 @@
+package com.gdg.Todak.member.controller;
+
+import com.gdg.Todak.member.controller.request.LoginRequest;
+import com.gdg.Todak.member.controller.request.SignupRequest;
+import com.gdg.Todak.member.service.request.SignupServiceRequest;
+import com.gdg.Todak.member.service.response.MemberResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+class MemberControllerTest extends ControllerTestSupport {
+
+    @DisplayName("회원가입을 한다.")
+    @Test
+    void signup() throws Exception {
+        // given
+        String username = "testUsername";
+        String password = "testPassword";
+
+        SignupRequest request = SignupRequest.builder()
+                .username(username)
+                .password(password)
+                .build();
+
+        when(memberService.signup(any(SignupServiceRequest.class))).thenReturn(
+                MemberResponse.of(username));
+
+        // when // then
+        mockMvc.perform(
+                        post("/api/users/signup")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.message").value("OK"));
+    }
+
+    @DisplayName("회원가입 시 username은 3글자 이상이어야 한다.")
+    @Test
+    void signupWithShortUsername() throws Exception {
+        // given
+        String username = "us";
+        String password = "testPassword";
+
+        SignupRequest request = SignupRequest.builder()
+                .username(username)
+                .password(password)
+                .build();
+
+        // when // then
+        mockMvc.perform(
+                        post("/api/users/signup")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("400"))
+                .andExpect(jsonPath("$.status").value("BAD_REQUEST"));
+    }
+
+    @DisplayName("회원가입 시 password는 8글자 이상이어야 한다.")
+    @Test
+    void signupWithShortPassword() throws Exception {
+        // given
+        String username = "testUsername";
+        String password = "passwor";
+
+        SignupRequest request = SignupRequest.builder()
+                .username(username)
+                .password(password)
+                .build();
+
+        // when // then
+        mockMvc.perform(
+                        post("/api/users/signup")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("400"))
+                .andExpect(jsonPath("$.status").value("BAD_REQUEST"));
+    }
+
+    @DisplayName("로그인을 한다.")
+    @Test
+    void login() throws Exception {
+        // given
+        String username = "testUsername";
+        String password = "testPassword";
+
+        LoginRequest request = new LoginRequest(username, password);
+
+        // when // then
+        mockMvc.perform(
+                        post("/api/users/login")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("OK"));
+    }
+
+}

--- a/src/test/java/com/gdg/Todak/member/controller/TestWebConfig.java
+++ b/src/test/java/com/gdg/Todak/member/controller/TestWebConfig.java
@@ -1,0 +1,32 @@
+package com.gdg.Todak.member.controller;
+
+import com.gdg.Todak.member.Interceptor.LoginCheckInterceptor;
+import com.gdg.Todak.member.resolver.LoginMemberArgumentResolver;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import static org.mockito.ArgumentMatchers.any;
+
+@TestConfiguration
+public class TestWebConfig {
+
+    @Bean
+    public LoginCheckInterceptor loginCheckInterceptor() {
+        LoginCheckInterceptor mockInterceptor = Mockito.mock(LoginCheckInterceptor.class);
+        Mockito.when(mockInterceptor.preHandle(
+                any(HttpServletRequest.class),
+                any(HttpServletResponse.class),
+                any(Object.class)
+        )).thenReturn(true);
+        return mockInterceptor;
+    }
+
+    @Bean
+    public LoginMemberArgumentResolver loginMemberArgumentResolver() {
+        return Mockito.mock(LoginMemberArgumentResolver.class);
+    }
+
+}

--- a/src/test/java/com/gdg/Todak/member/resolver/LoginMemberArgumentResolverTest.java
+++ b/src/test/java/com/gdg/Todak/member/resolver/LoginMemberArgumentResolverTest.java
@@ -1,0 +1,82 @@
+package com.gdg.Todak.member.resolver;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gdg.Todak.member.domain.AuthenticateUser;
+import com.gdg.Todak.member.domain.Role;
+import com.gdg.Todak.member.util.JwtProvider;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.context.request.NativeWebRequest;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LoginMemberArgumentResolverTest {
+
+    @Mock
+    MethodParameter parameter;
+
+    @Mock
+    NativeWebRequest webRequest;
+
+    @Mock
+    HttpServletRequest request;
+
+    @Mock
+    JwtProvider jwtProvider;
+
+    @Mock
+    ObjectMapper objectMapper;
+
+    @InjectMocks
+    LoginMemberArgumentResolver resolver;
+
+    @DisplayName("ArgumentResolver에 의해 헤더의 accessToken이 AuthenticatedUser로 resolve 된다.")
+    @Test
+    void LoginMemberArgumentResolverTest() throws Exception {
+        // given
+        String username = "username";
+
+        String accessToken = "Bearer abc";
+
+        AuthenticateUser user = AuthenticateUser.builder()
+                .username(username)
+                .roles(Set.of(Role.USER))
+                .build();
+
+        Map<String, Object> claimsMap = new HashMap<>();
+        claimsMap.put("authenticateUser", user);
+
+        Claims mockClaims = Jwts.claims(claimsMap);
+
+        when(webRequest.getNativeRequest()).thenReturn(request);
+        when(request.getHeader("Authorization")).thenReturn(accessToken);
+
+        when(jwtProvider.getClaims(any(String.class))).thenReturn(mockClaims);
+
+        when(objectMapper.readValue(any(String.class), eq(AuthenticateUser.class))).thenReturn(user);
+
+        // when
+        AuthenticateUser resolvedUser = (AuthenticateUser) resolver.resolveArgument(parameter, null,
+                webRequest, null);
+
+        // then
+        assertThat(resolvedUser.getUsername()).isEqualTo(username);
+    }
+
+}

--- a/src/test/java/com/gdg/Todak/member/service/AuthServiceTest.java
+++ b/src/test/java/com/gdg/Todak/member/service/AuthServiceTest.java
@@ -1,0 +1,118 @@
+package com.gdg.Todak.member.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gdg.Todak.member.domain.AuthenticateUser;
+import com.gdg.Todak.member.domain.Jwt;
+import com.gdg.Todak.member.exception.UnauthorizedException;
+import com.gdg.Todak.member.repository.MemberRepository;
+import com.gdg.Todak.member.repository.MemberRoleRepository;
+import com.gdg.Todak.member.service.request.LoginServiceRequest;
+import com.gdg.Todak.member.service.request.SignupServiceRequest;
+import com.gdg.Todak.member.service.request.UpdateAccessTokenServiceRequest;
+import com.gdg.Todak.member.util.JwtProvider;
+import io.jsonwebtoken.Claims;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+class AuthServiceTest {
+
+    @Autowired
+    private AuthService authService;
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    public String refreshToken;
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private MemberRoleRepository memberRoleRepository;
+
+    @Autowired
+    private RedisTemplate redisTemplate;
+
+    @AfterEach
+    void tearDown() {
+        memberRoleRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+
+        if (refreshToken != null) {
+            redisTemplate.delete(refreshToken);
+        }
+    }
+
+    @DisplayName("리프레시 토큰이 유효하면 새로운 액세스 토큰을 발급한다.")
+    @Test
+    void validRefreshTokenTest() throws JsonProcessingException {
+        // given
+        String username = "test_username";
+        String password = "test_password";
+
+        createMember(username, password);
+
+        LoginServiceRequest loginRequest = LoginServiceRequest.builder()
+                .username(username)
+                .password(password)
+                .build();
+
+        Jwt jwt = memberService.login(loginRequest);
+        refreshToken = jwt.getRefreshToken();
+
+        // when
+        UpdateAccessTokenServiceRequest updateAccessTokenServiceRequest = UpdateAccessTokenServiceRequest.builder()
+                .refreshToken(jwt.getRefreshToken())
+                .build();
+
+        Jwt newJwt = authService.updateAccessToken(updateAccessTokenServiceRequest);
+
+        Claims claims = jwtProvider.getClaims(newJwt.getAccessToken());
+        String json = claims.get(jwtProvider.AUTHENTICATE_USER).toString();
+        AuthenticateUser authenticateUser = objectMapper.readValue(json, AuthenticateUser.class);
+
+        // then
+        assertThat(authenticateUser.getUsername()).isEqualTo(username);
+    }
+
+    @DisplayName("리프레시 토큰이 유효하지 않으면 예외가 발생한다.")
+    @Test
+    void invalidRefreshTokenTest() {
+        // given
+        String invalidRefreshToken = "invalid_refresh_token";
+
+        // when
+        UpdateAccessTokenServiceRequest updateAccessTokenServiceRequest = UpdateAccessTokenServiceRequest.builder()
+                .refreshToken(invalidRefreshToken)
+                .build();
+
+        // then
+        assertThatThrownBy(() -> authService.updateAccessToken(updateAccessTokenServiceRequest))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasMessage("리프레시 토큰이 만료되었습니다.");
+    }
+
+    private void createMember(String username, String password) {
+        SignupServiceRequest request = SignupServiceRequest.builder()
+                .username(username)
+                .password(password)
+                .build();
+
+        memberService.signup(request);
+    }
+
+}

--- a/src/test/java/com/gdg/Todak/member/service/MemberServiceTest.java
+++ b/src/test/java/com/gdg/Todak/member/service/MemberServiceTest.java
@@ -1,0 +1,190 @@
+package com.gdg.Todak.member.service;
+
+import com.gdg.Todak.member.domain.*;
+import com.gdg.Todak.member.exception.UnauthorizedException;
+import com.gdg.Todak.member.repository.MemberRepository;
+import com.gdg.Todak.member.repository.MemberRoleRepository;
+import com.gdg.Todak.member.service.request.CheckUsernameServiceRequest;
+import com.gdg.Todak.member.service.request.LoginServiceRequest;
+import com.gdg.Todak.member.service.request.SignupServiceRequest;
+import com.gdg.Todak.member.service.response.CheckUsernameServiceResponse;
+import com.gdg.Todak.member.service.response.MeResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+class MemberServiceTest {
+
+    public static final String USERNAME = "test_username";
+    public static final String PASSWORD = "test_password";
+
+    public String refreshToken;
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private MemberRoleRepository memberRoleRepository;
+
+    @Autowired
+    private RedisTemplate redisTemplate;
+
+    @AfterEach
+    void tearDown() {
+        memberRoleRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+
+        if (refreshToken != null) {
+            redisTemplate.delete(refreshToken);
+        }
+    }
+
+    @DisplayName("회원마다 랜덤 salt를 생성하여 salt와 함께 비밀번호를 인코딩하여 저장한다.")
+    @Test
+    void signupTest() {
+        // given
+        createMember(USERNAME, PASSWORD);
+
+        // when
+        Member findMember = memberRepository.findByUsername(USERNAME).get();
+
+        // then
+        assertThat(findMember.getUsername()).isEqualTo(USERNAME);
+        assertThat(findMember.getPassword()).isNotEqualTo(PASSWORD);
+        assertThat(findMember.getMemberRoles()).hasSize(1)
+                .extracting(MemberRole::getRole)
+                .containsExactly(Role.USER);
+    }
+
+    @DisplayName("존재하지 않는 username으로 로그인 시 예외가 발생한다.")
+    @Test
+    void nonexistentUsernameLoginTest() {
+        // given
+        createMember(USERNAME, PASSWORD);
+
+        String nonexistentUsername = "nonexistentUsername";
+
+        LoginServiceRequest request = LoginServiceRequest.builder()
+                .username(nonexistentUsername)
+                .password(PASSWORD)
+                .build();
+
+        // when // then
+        assertThatThrownBy(() -> memberService.login(request))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasMessage("멤버가 존재하지 않습니다.");
+    }
+
+    @DisplayName("존재하지 않는 password로 로그인 시 예외가 발생한다.")
+    @Test
+    void wrongPasswordLoginTest() {
+        // given
+        createMember(USERNAME, PASSWORD);
+
+        String wrongPassword = "wrongPassword";
+
+        LoginServiceRequest request = LoginServiceRequest.builder()
+                .username(USERNAME)
+                .password(wrongPassword)
+                .build();
+
+        // when // then
+        assertThatThrownBy(() -> memberService.login(request))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasMessage("비밀번호가 올바르지 않습니다.");
+    }
+
+    @DisplayName("올바른 username과 password로 로그인 시 accessToken과 refreshToken이 반환된다.")
+    @Test
+    void loginTest() {
+        // given
+        createMember(USERNAME, PASSWORD);
+
+        LoginServiceRequest request = LoginServiceRequest.builder()
+                .username(USERNAME)
+                .password(PASSWORD)
+                .build();
+
+        // when
+        Jwt jwtToken = memberService.login(request);
+        refreshToken = jwtToken.getRefreshToken();
+
+        // then
+        Long memberId = (Long) redisTemplate.opsForValue().get(refreshToken);
+        assertThat(memberId).isNotNull();
+    }
+
+    @DisplayName("이미 존재하는 username이면 true를 반환한다.")
+    @Test
+    void existUsernameCheckTest() {
+        // given
+        createMember(USERNAME, PASSWORD);
+
+        CheckUsernameServiceRequest request = CheckUsernameServiceRequest.builder()
+                .username(USERNAME)
+                .build();
+
+        // when
+        CheckUsernameServiceResponse result = memberService.checkUsername(request);
+
+        // then
+        assertThat(result.getExists()).isEqualTo(true);
+    }
+
+    @DisplayName("존재하지 않는 username이면 false를 반환한다.")
+    @Test
+    void nonexistentUsernameCheckTest() {
+        // given
+        createMember(USERNAME, PASSWORD);
+
+        CheckUsernameServiceRequest request = CheckUsernameServiceRequest.builder()
+                .username(USERNAME + "nonexistent")
+                .build();
+
+        // when
+        CheckUsernameServiceResponse result = memberService.checkUsername(request);
+
+        // then
+        assertThat(result.getExists()).isEqualTo(false);
+    }
+
+    @DisplayName("마이페이지에서 username이 반환된다")
+    @Test
+    void meTest() {
+        // given
+        createMember(USERNAME, PASSWORD);
+
+        Set<Role> roles = Set.of(Role.USER);
+
+        AuthenticateUser user = AuthenticateUser.builder()
+                .username(USERNAME)
+                .roles(roles)
+                .build();
+
+        // when
+        MeResponse me = memberService.me(user);
+
+        // then
+        assertThat(me.getUsername()).isEqualTo(USERNAME);
+    }
+
+    private void createMember(String username, String password) {
+        SignupServiceRequest request = SignupServiceRequest.builder()
+                .username(username)
+                .password(password)
+                .build();
+
+        memberService.signup(request);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #11 


## 📝 작업 내용
> 인증기능을 직접 구현해보았습니다.
> JWT 방식의 accessToken과 refreshToken 사용하였습니다.
> 현재 로그인 리졸버가 구현되어 있어 @Login 어노테이션으로 사용하시면 AuthenteUser에 담깁니다.

### 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)

테스트 관련 강의에서 계층별 결합도를 줄이기 위해 dto를 만들어 서로 데이터를 전달하는 방식이 있다고 해서 그렇게 해봤는데 좀 코드양이 급격하게 늘어난 느낌도 들긴 합니다. 이렇게 사용하는거 어떻게 생각하시는지 궁금합니다.

Interceptor, Resolver 모두 목객체로 테스트 작성하였는데 다른 좋은 방법 알고 계시면 알려주시면 감사하겠습니다.

레디스 호스트, 포트 그리고 jwt 사인에 사용되는 시크릿은 일단 이렇게
@Value("${secrets.REDIS_HOST}")
@Value("${secrets.REDIS_PORT}")
@Value("${secrets.SECRET_KEY}")

이런식으로 불러오게 해놨는데 이렇게 하면 될까요?

그리고 아까 걱정했던 인덴트 문제는 막상 커밋하니까 별 문제 없는 것 같습니다.

## ⏰ 현재 버그
버그는 아닌데 imageUrl을 넣었으니까 s3로 업로드 해서 프사 바꿀 수 있는 기능 추가하여야 할 것 같습니다.

## ✏ Git Close
> close #11 
