### PR TITLE
Feat: 스웨거 Authorization 기능 추가 및 member constraint 추가

### DIFF
--- a/src/main/java/com/gdg/Todak/common/config/SwaggerConfig.java
+++ b/src/main/java/com/gdg/Todak/common/config/SwaggerConfig.java
@@ -3,23 +3,39 @@ package com.gdg.Todak.common.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
 
+    public static final String BEARER_AUTH = "BearerAuth";
+
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
                 .components(new Components())
-                .info(apiInfo());
+                .info(createApiInfo())
+                .addSecurityItem(new SecurityRequirement().addList(BEARER_AUTH))
+                .schemaRequirement(BEARER_AUTH, createSecurityScheme());
     }
 
-    private Info apiInfo() {
+    private Info createApiInfo() {
         return new Info()
                 .title("2025 GDG 솔루션 챌린지 - 경북대 1팀 - Todak Service 명세서")
                 .description("[Team Notion 바로가기](https://www.notion.so/2025-GDG-1-Todak-183260f9e1bd80438092de22a6dd801a)")
                 .version("0.0.1");
+    }
+
+    public SecurityScheme createSecurityScheme() {
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name("Authorization");
+        return securityScheme;
     }
 }

--- a/src/main/java/com/gdg/Todak/member/controller/AuthController.java
+++ b/src/main/java/com/gdg/Todak/member/controller/AuthController.java
@@ -5,6 +5,7 @@ import com.gdg.Todak.member.controller.request.UpdateAccessTokenRequest;
 import com.gdg.Todak.member.domain.Jwt;
 import com.gdg.Todak.member.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -12,8 +13,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
-@RequestMapping("/api/auth")
+@RequestMapping("/api/v1/auth")
 @RestController
+@Tag(name = "인증", description = "인증 관련 API")
 public class AuthController {
 
     private final AuthService authService;

--- a/src/main/java/com/gdg/Todak/member/controller/AuthController.java
+++ b/src/main/java/com/gdg/Todak/member/controller/AuthController.java
@@ -4,6 +4,7 @@ import com.gdg.Todak.common.domain.ApiResponse;
 import com.gdg.Todak.member.controller.request.UpdateAccessTokenRequest;
 import com.gdg.Todak.member.domain.Jwt;
 import com.gdg.Todak.member.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -18,7 +19,8 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/refresh")
-    public ApiResponse<Jwt> updateRefreshToken(@RequestBody UpdateAccessTokenRequest request) {
+    @Operation(summary = "액세스 토큰 갱신", description = "리프레시 토큰이 유효하다면 액세스 토큰을 갱신한다.")
+    public ApiResponse<Jwt> updateAccessTokenToken(@RequestBody UpdateAccessTokenRequest request) {
         return ApiResponse.ok(authService.updateAccessToken(request.toServiceRequest()));
     }
 

--- a/src/main/java/com/gdg/Todak/member/controller/MemberController.java
+++ b/src/main/java/com/gdg/Todak/member/controller/MemberController.java
@@ -13,6 +13,7 @@ import com.gdg.Todak.member.service.response.CheckUsernameServiceResponse;
 import com.gdg.Todak.member.service.response.LogoutResponse;
 import com.gdg.Todak.member.service.response.MeResponse;
 import com.gdg.Todak.member.service.response.MemberResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -28,28 +29,33 @@ public class MemberController {
     private final MemberService memberService;
 
     @PostMapping("/check-username")
+    @Operation(summary = "유저명 중복 체크", description = "유저명이 존재하는지 체크한다. 존재하면 True, 존재하지 않으면 False를 반환한다.")
     public ApiResponse<CheckUsernameServiceResponse> checkUsername(
             @RequestBody CheckUsernameRequest request) {
         return ApiResponse.ok(memberService.checkUsername(request.toServiceRequest()));
     }
 
     @PostMapping("/signup")
+    @Operation(summary = "회원가입", description = "유저명과 비밀번호로 회원가입한다. 유저명은 3글자 이상 20글자 이하, 비밀번호는 8글자 이상 16글자 이하이다.")
     public ApiResponse<MemberResponse> signup(@RequestBody @Validated SignupRequest request) {
         return ApiResponse.ok(memberService.signup(request.toServiceRequest()));
     }
 
     @PostMapping("/login")
+    @Operation(summary = "로그인", description = "유저명과 비밀번호로 로그인한다. 성공시 accessToken과 refreshToken이 반환된다.")
     public ApiResponse<Jwt> login(@RequestBody LoginRequest request) {
         return ApiResponse.ok(memberService.login(request.toServiceRequest()));
     }
 
     @PostMapping("/logout")
+    @Operation(summary = "로그아웃", description = "리프레시 토큰을 삭제하여 로그아웃한다.")
     public ApiResponse<LogoutResponse> logout(@Login AuthenticateUser user,
                                               @RequestBody LogoutRequest request) {
         return ApiResponse.ok(memberService.logout(user, request.toServiceRequest()));
     }
 
     @PostMapping("/me")
+    @Operation(summary = "마이페이지", description = "로그인이 된 상태유저명과 프로필 사진 Url을 반환한다.")
     public ApiResponse<MeResponse> me(@Login AuthenticateUser user) {
         return ApiResponse.ok(memberService.me(user));
     }

--- a/src/main/java/com/gdg/Todak/member/controller/MemberController.java
+++ b/src/main/java/com/gdg/Todak/member/controller/MemberController.java
@@ -14,6 +14,7 @@ import com.gdg.Todak.member.service.response.LogoutResponse;
 import com.gdg.Todak.member.service.response.MeResponse;
 import com.gdg.Todak.member.service.response.MemberResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -22,8 +23,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
-@RequestMapping("/api/users")
+@RequestMapping("/api/v1/users")
 @RestController
+@Tag(name = "멤버", description = "멤버 관련 API")
 public class MemberController {
 
     private final MemberService memberService;

--- a/src/main/java/com/gdg/Todak/member/controller/advice/MemberControllerAdvice.java
+++ b/src/main/java/com/gdg/Todak/member/controller/advice/MemberControllerAdvice.java
@@ -32,11 +32,20 @@ public class MemberControllerAdvice {
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    @ExceptionHandler({BindException.class, DataIntegrityViolationException.class})
+    @ExceptionHandler(BindException.class)
     public ApiResponse<Object> bindException(BindException e) {
         return ApiResponse.of(
                 HttpStatus.BAD_REQUEST,
                 e.getBindingResult().getAllErrors().get(0).getDefaultMessage()
+        );
+    }
+
+    @ResponseStatus(HttpStatus.CONFLICT)
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ApiResponse<Object> handleDataIntegrityViolationException(DataIntegrityViolationException e) {
+        return ApiResponse.of(
+                HttpStatus.CONFLICT,
+                e.getMostSpecificCause().getMessage()
         );
     }
 }

--- a/src/main/java/com/gdg/Todak/member/controller/advice/MemberControllerAdvice.java
+++ b/src/main/java/com/gdg/Todak/member/controller/advice/MemberControllerAdvice.java
@@ -3,6 +3,7 @@ package com.gdg.Todak.member.controller.advice;
 import com.gdg.Todak.common.domain.ApiResponse;
 import com.gdg.Todak.member.exception.EncryptionException;
 import com.gdg.Todak.member.exception.UnauthorizedException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -31,7 +32,7 @@ public class MemberControllerAdvice {
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    @ExceptionHandler(BindException.class)
+    @ExceptionHandler({BindException.class, DataIntegrityViolationException.class})
     public ApiResponse<Object> bindException(BindException e) {
         return ApiResponse.of(
                 HttpStatus.BAD_REQUEST,

--- a/src/main/java/com/gdg/Todak/member/domain/Member.java
+++ b/src/main/java/com/gdg/Todak/member/domain/Member.java
@@ -19,6 +19,7 @@ public class Member {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(unique = true)
     private String username;
 
     private String password;

--- a/src/main/java/com/gdg/Todak/member/exception/MemberException.java
+++ b/src/main/java/com/gdg/Todak/member/exception/MemberException.java
@@ -1,8 +1,0 @@
-package com.gdg.Todak.member.exception;
-
-public class MemberException extends RuntimeException {
-
-    public MemberException(String message, Throwable cause) {
-        super(message, cause);
-    }
-}

--- a/src/test/java/com/gdg/Todak/member/controller/AuthControllerTest.java
+++ b/src/test/java/com/gdg/Todak/member/controller/AuthControllerTest.java
@@ -36,7 +36,7 @@ class AuthControllerTest extends ControllerTestSupport {
 
         // then
         mockMvc.perform(
-                        post("/api/auth/refresh")
+                        post("/api/v1/auth/refresh")
                                 .content(objectMapper.writeValueAsString(request))
                                 .contentType(MediaType.APPLICATION_JSON)
                 )

--- a/src/test/java/com/gdg/Todak/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/gdg/Todak/member/controller/MemberControllerTest.java
@@ -35,7 +35,7 @@ class MemberControllerTest extends ControllerTestSupport {
 
         // when // then
         mockMvc.perform(
-                        post("/api/users/signup")
+                        post("/api/v1/users/signup")
                                 .content(objectMapper.writeValueAsString(request))
                                 .contentType(MediaType.APPLICATION_JSON)
                 )
@@ -60,7 +60,7 @@ class MemberControllerTest extends ControllerTestSupport {
 
         // when // then
         mockMvc.perform(
-                        post("/api/users/signup")
+                        post("/api/v1/users/signup")
                                 .content(objectMapper.writeValueAsString(request))
                                 .contentType(MediaType.APPLICATION_JSON)
                 )
@@ -84,7 +84,7 @@ class MemberControllerTest extends ControllerTestSupport {
 
         // when // then
         mockMvc.perform(
-                        post("/api/users/signup")
+                        post("/api/v1/users/signup")
                                 .content(objectMapper.writeValueAsString(request))
                                 .contentType(MediaType.APPLICATION_JSON)
                 )
@@ -105,7 +105,7 @@ class MemberControllerTest extends ControllerTestSupport {
 
         // when // then
         mockMvc.perform(
-                        post("/api/users/login")
+                        post("/api/v1/users/login")
                                 .content(objectMapper.writeValueAsString(request))
                                 .contentType(MediaType.APPLICATION_JSON)
                 )

--- a/src/test/java/com/gdg/Todak/member/domain/MemberTest.java
+++ b/src/test/java/com/gdg/Todak/member/domain/MemberTest.java
@@ -1,0 +1,35 @@
+package com.gdg.Todak.member.domain;
+
+import com.gdg.Todak.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest
+class MemberTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @DisplayName("중복된 유저명으로 생성할 수 없다.")
+    @Test
+    void duplicateUsernameTest() {
+        // given
+        String username = "username";
+
+        Member member1 = Member.of(username, "password", "imageUrl", "salt");
+        Member member2 = Member.of(username, "password", "imageUrl", "salt");
+
+        // when
+        memberRepository.save(member1);
+
+        // then
+        assertThatThrownBy(() -> memberRepository.save(member2))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> -


## 📝 작업 내용
> swagger authorization 기능 추가
> 스웨거 MemberController, AuthController에 Operation 설명 추가
> member username에 unique constraint 추가 및 테스트 추가
> 글로벌 어드바이스에서 DataIntegrityViolationException 핸들링 추가
> MemberException은 사용하는 곳이 없어 삭제하였습니다.

### 스크린샷 (선택)
-

## 💬 리뷰 요구사항(선택)
> 현재 DataIntegrityViolationException 핸들링 부분에서 에러 메시지를 e.getMostSpecificCause().getMessage() 이렇게 받아오고 이러면

msg = Unique index or primary key violation: "PUBLIC.CONSTRAINT_INDEX_8 ON PUBLIC.MEMBER(USERNAME NULLS FIRST) VALUES ( /* 1 */ 'username' )"; SQL statement:

이런식으로 나오는데 적절할까요? 그냥 간단하게

중복 값이나 유효하지 않은 값이 들어왔습니다

이정도로 처리해도 될지 고민입니다.


## ⏰ 현재 버그
-

## ✏ Git Close
> close #-
