### PR TITLE
Feat: Add diary and friend logic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,8 @@ dependencies {
     testAnnotationProcessor 'org.projectlombok:lombok'
 
     // Test Dependencies
+    runtimeOnly 'com.h2database:h2'
+    testImplementation 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 

--- a/src/main/java/com/gdg/Todak/diary/controller/DiaryController.java
+++ b/src/main/java/com/gdg/Todak/diary/controller/DiaryController.java
@@ -26,6 +26,7 @@ public class DiaryController {
 
     @PostMapping
     @Operation(summary = "일기 작성 / 감정 등록", description = "일기를 작성한다. 감정만 등록하기도 가능. 감정은 HAPPY, SAD, ANGRY, EXCITED, NEUTRAL")
+    @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<Void> writeDiary(@Parameter(hidden = true) @Login AuthenticateUser authenticateUser, @RequestBody DiaryRequest diaryRequest) {
         diaryService.writeDiary(authenticateUser.getUsername(), diaryRequest);
         return ApiResponse.of(HttpStatus.CREATED, "작성되었습니다.");

--- a/src/main/java/com/gdg/Todak/diary/controller/DiaryController.java
+++ b/src/main/java/com/gdg/Todak/diary/controller/DiaryController.java
@@ -1,23 +1,20 @@
 package com.gdg.Todak.diary.controller;
 
 import com.gdg.Todak.common.domain.ApiResponse;
+import com.gdg.Todak.diary.dto.DiaryDetailResponse;
 import com.gdg.Todak.diary.dto.DiaryRequest;
-import com.gdg.Todak.diary.dto.DiaryResponse;
-import com.gdg.Todak.diary.dto.EmotionRequest;
+import com.gdg.Todak.diary.dto.DiarySummaryResponse;
 import com.gdg.Todak.diary.service.DiaryService;
+import com.gdg.Todak.member.domain.AuthenticateUser;
+import com.gdg.Todak.member.resolver.Login;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,50 +26,43 @@ public class DiaryController {
 
     @PostMapping
     @Operation(summary = "일기 작성 / 감정 등록", description = "일기를 작성한다. 감정만 등록하기도 가능. 감정은 HAPPY, SAD, ANGRY, EXCITED, NEUTRAL")
-    public ApiResponse<Void> writeDiary(@RequestBody DiaryRequest diaryRequest) {
-        diaryService.writeDiary(diaryRequest);
+    public ApiResponse<Void> writeDiary(@Parameter(hidden = true) @Login AuthenticateUser authenticateUser, @RequestBody DiaryRequest diaryRequest) {
+        diaryService.writeDiary(authenticateUser.getUsername(), diaryRequest);
         return ApiResponse.of(HttpStatus.CREATED, "작성되었습니다.");
     }
 
-    @GetMapping("/all")
-    @Parameters({
-            @Parameter(in = ParameterIn.QUERY, name = "page", description = "페이지 번호 (0부터 시작)", example = "0", schema = @Schema(type = "integer", defaultValue = "0")),
-            @Parameter(in = ParameterIn.QUERY, name = "size", description = "페이지 크기", example = "10", schema = @Schema(type = "integer", defaultValue = "10")),
-            @Parameter(in = ParameterIn.QUERY, name = "sort", description = "정렬 기준 (속성,오름차순|내림차순)", example = "createdAt,desc", schema = @Schema(type = "string"))
-    })
-    @Operation(summary = "모든 일기 불러오기", description = "모든 일기를 불러온다 (페이징 처리)")
-    public ApiResponse<Page<DiaryResponse>> getAllDiary(@Parameter(hidden = true)
-                                                        @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC)
-                                                        Pageable pageable) {
-        Page<DiaryResponse> diaryResponses = diaryService.readAllDiary(pageable);
+    @GetMapping("/own/{year}/{month}")
+    @Operation(summary = "본인의 년/월에 해당하는 모든 일기 불러오기", description = "본인이 작성한 일기 중 year, month에 해당하는 모든 일기를 불러온다.")
+    public ApiResponse<List<DiarySummaryResponse>> getOwnAllDiary(@Parameter(hidden = true) @Login AuthenticateUser authenticateUser, @PathVariable("year") int year, @PathVariable("month") int month) {
+        List<DiarySummaryResponse> diaryResponses = diaryService.getOwnSummaryByYearAndMonth(authenticateUser.getUsername(), year, month);
+        return ApiResponse.ok(diaryResponses);
+    }
+
+    @GetMapping("/friend/{friendName}/{year}/{month}")
+    @Operation(summary = "친구의 년/월에 해당하는 모든 일기 불러오기", description = "친구가 작성한 일기 중 year, month에 해당하는 모든 일기를 불러온다.")
+    public ApiResponse<List<DiarySummaryResponse>> getAllDiaryByFriend(@Parameter(hidden = true) @Login AuthenticateUser authenticateUser, @PathVariable("friendName") String friendName, @PathVariable("year") int year, @PathVariable("month") int month) {
+        List<DiarySummaryResponse> diaryResponses = diaryService.getFriendSummaryByYearAndMonth(authenticateUser.getUsername(), friendName, year, month);
         return ApiResponse.ok(diaryResponses);
     }
 
     @GetMapping("/{diaryId}")
-    @Operation(summary = "일기 상세보기", description = "diaryId에 해당하는 일기를 확인한다")
-    public ApiResponse<DiaryResponse> getDiary(@PathVariable("diaryId") Long diaryId) {
-        DiaryResponse diaryResponse = diaryService.readDiary(diaryId);
-        return ApiResponse.ok(diaryResponse);
+    @Operation(summary = "일기 상세보기", description = "본인 또는 친구의 diaryId에 해당하는 일기를 확인한다.")
+    public ApiResponse<DiaryDetailResponse> getDiary(@Parameter(hidden = true) @Login AuthenticateUser authenticateUser, @PathVariable("diaryId") Long diaryId) {
+        DiaryDetailResponse diaryDetailResponse = diaryService.readDiary(authenticateUser.getUsername(), diaryId);
+        return ApiResponse.ok(diaryDetailResponse);
     }
 
     @PutMapping("/{diaryId}")
-    @Operation(summary = "일기 수정하기", description = "diaryId에 해당하는 일기를 수정한다")
-    public ApiResponse<Void> updateDiary(@PathVariable("diaryId") Long diaryId, @RequestBody DiaryRequest diaryRequest) {
-        diaryService.updateDiary(diaryId, diaryRequest);
-        return ApiResponse.of(HttpStatus.OK, "수정되었습니다.");
-    }
-
-    @PutMapping("/emotion/{diaryId}")
-    @Operation(summary = "감정 수정하기", description = "diaryId에 해당하는 일기의 감정을 수정한다. 감정은 HAPPY, SAD, ANGRY, EXCITED, NEUTRAL")
-    public ApiResponse<Void> updateEmotion(@PathVariable("diaryId") Long diaryId, @RequestBody EmotionRequest emotionRequest) {
-        diaryService.updateDiaryEmotion(diaryId, emotionRequest);
+    @Operation(summary = "일기 수정하기", description = "diaryId에 해당하는 일기를 수정한다.")
+    public ApiResponse<Void> updateDiary(@Parameter(hidden = true) @Login AuthenticateUser authenticateUser, @PathVariable("diaryId") Long diaryId, @RequestBody DiaryRequest diaryRequest) {
+        diaryService.updateDiary(authenticateUser.getUsername(), diaryId, diaryRequest);
         return ApiResponse.of(HttpStatus.OK, "수정되었습니다.");
     }
 
     @DeleteMapping("{diaryId}")
-    @Operation(summary = "일기 삭제하기", description = "diaryId에 해당하는 일기를 삭제한다")
-    public ApiResponse<Void> deteleDiary(@PathVariable("diaryId") Long diaryId) {
-        diaryService.deleteDiary(diaryId);
+    @Operation(summary = "일기 삭제하기", description = "diaryId에 해당하는 일기를 삭제한다.")
+    public ApiResponse<Void> deleteDiary(@Parameter(hidden = true) @Login AuthenticateUser authenticateUser, @PathVariable("diaryId") Long diaryId) {
+        diaryService.deleteDiary(authenticateUser.getUsername(), diaryId);
         return ApiResponse.of(HttpStatus.OK, "삭제되었습니다.");
     }
 }

--- a/src/main/java/com/gdg/Todak/diary/controller/DiaryController.java
+++ b/src/main/java/com/gdg/Todak/diary/controller/DiaryController.java
@@ -3,6 +3,7 @@ package com.gdg.Todak.diary.controller;
 import com.gdg.Todak.common.domain.ApiResponse;
 import com.gdg.Todak.diary.dto.DiaryDetailResponse;
 import com.gdg.Todak.diary.dto.DiaryRequest;
+import com.gdg.Todak.diary.dto.DiarySearchRequest;
 import com.gdg.Todak.diary.dto.DiarySummaryResponse;
 import com.gdg.Todak.diary.service.DiaryService;
 import com.gdg.Todak.member.domain.AuthenticateUser;
@@ -35,14 +36,16 @@ public class DiaryController {
     @GetMapping("/me/{year}/{month}")
     @Operation(summary = "본인의 년/월에 해당하는 모든 일기 불러오기", description = "본인이 작성한 일기 중 year, month에 해당하는 모든 일기를 불러온다.")
     public ApiResponse<List<DiarySummaryResponse>> getMyAllDiary(@Parameter(hidden = true) @Login AuthenticateUser authenticateUser, @PathVariable("year") int year, @PathVariable("month") int month) {
-        List<DiarySummaryResponse> diaryResponses = diaryService.getMySummaryByYearAndMonth(authenticateUser.getUsername(), year, month);
+        DiarySearchRequest diarySearchRequest = new DiarySearchRequest(year, month);
+        List<DiarySummaryResponse> diaryResponses = diaryService.getMySummaryByYearAndMonth(authenticateUser.getUsername(), diarySearchRequest);
         return ApiResponse.ok(diaryResponses);
     }
 
     @GetMapping("/friend/{friendName}/{year}/{month}")
     @Operation(summary = "친구의 년/월에 해당하는 모든 일기 불러오기", description = "친구가 작성한 일기 중 year, month에 해당하는 모든 일기를 불러온다.")
     public ApiResponse<List<DiarySummaryResponse>> getAllDiaryByFriend(@Parameter(hidden = true) @Login AuthenticateUser authenticateUser, @PathVariable("friendName") String friendName, @PathVariable("year") int year, @PathVariable("month") int month) {
-        List<DiarySummaryResponse> diaryResponses = diaryService.getFriendSummaryByYearAndMonth(authenticateUser.getUsername(), friendName, year, month);
+        DiarySearchRequest diarySearchRequest = new DiarySearchRequest(year, month);
+        List<DiarySummaryResponse> diaryResponses = diaryService.getFriendSummaryByYearAndMonth(authenticateUser.getUsername(), friendName, diarySearchRequest);
         return ApiResponse.ok(diaryResponses);
     }
 

--- a/src/main/java/com/gdg/Todak/diary/controller/DiaryController.java
+++ b/src/main/java/com/gdg/Todak/diary/controller/DiaryController.java
@@ -32,10 +32,10 @@ public class DiaryController {
         return ApiResponse.of(HttpStatus.CREATED, "작성되었습니다.");
     }
 
-    @GetMapping("/own/{year}/{month}")
+    @GetMapping("/me/{year}/{month}")
     @Operation(summary = "본인의 년/월에 해당하는 모든 일기 불러오기", description = "본인이 작성한 일기 중 year, month에 해당하는 모든 일기를 불러온다.")
-    public ApiResponse<List<DiarySummaryResponse>> getOwnAllDiary(@Parameter(hidden = true) @Login AuthenticateUser authenticateUser, @PathVariable("year") int year, @PathVariable("month") int month) {
-        List<DiarySummaryResponse> diaryResponses = diaryService.getOwnSummaryByYearAndMonth(authenticateUser.getUsername(), year, month);
+    public ApiResponse<List<DiarySummaryResponse>> getMyAllDiary(@Parameter(hidden = true) @Login AuthenticateUser authenticateUser, @PathVariable("year") int year, @PathVariable("month") int month) {
+        List<DiarySummaryResponse> diaryResponses = diaryService.getMySummaryByYearAndMonth(authenticateUser.getUsername(), year, month);
         return ApiResponse.ok(diaryResponses);
     }
 

--- a/src/main/java/com/gdg/Todak/diary/controller/advice/DiaryControllerAdvice.java
+++ b/src/main/java/com/gdg/Todak/diary/controller/advice/DiaryControllerAdvice.java
@@ -1,17 +1,17 @@
-package com.gdg.Todak.friend.controller.advice;
+package com.gdg.Todak.diary.controller.advice;
 
 import com.gdg.Todak.common.domain.ApiResponse;
-import com.gdg.Todak.friend.exception.BadRequestException;
-import com.gdg.Todak.friend.exception.NotFoundException;
-import com.gdg.Todak.friend.exception.UnauthorizedException;
+import com.gdg.Todak.diary.exception.BadRequestException;
+import com.gdg.Todak.diary.exception.NotFoundException;
+import com.gdg.Todak.diary.exception.UnauthorizedException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-@RestControllerAdvice(basePackages = "com.gdg.Todak.friend")
-public class FriendControllerAdvice {
+@RestControllerAdvice(basePackages = "com.gdg.Todak.diary")
+public class DiaryControllerAdvice {
 
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
     @ExceptionHandler(UnauthorizedException.class)

--- a/src/main/java/com/gdg/Todak/diary/dto/DiaryDetailResponse.java
+++ b/src/main/java/com/gdg/Todak/diary/dto/DiaryDetailResponse.java
@@ -1,0 +1,14 @@
+package com.gdg.Todak.diary.dto;
+
+import com.gdg.Todak.diary.Emotion;
+
+import java.time.LocalDateTime;
+
+public record DiaryDetailResponse(
+        Long diaryId,
+        LocalDateTime createdAt,
+        String content,
+        Emotion emotion,
+        boolean isWriter
+) {
+}

--- a/src/main/java/com/gdg/Todak/diary/dto/DiaryRequest.java
+++ b/src/main/java/com/gdg/Todak/diary/dto/DiaryRequest.java
@@ -3,8 +3,7 @@ package com.gdg.Todak.diary.dto;
 import com.gdg.Todak.diary.Emotion;
 
 public record DiaryRequest(
-    String title,
-    String content,
-    Emotion emotion
+        String content,
+        Emotion emotion
 ) {
 }

--- a/src/main/java/com/gdg/Todak/diary/dto/DiarySearchRequest.java
+++ b/src/main/java/com/gdg/Todak/diary/dto/DiarySearchRequest.java
@@ -1,0 +1,7 @@
+package com.gdg.Todak.diary.dto;
+
+public record DiarySearchRequest(
+        int year,
+        int month
+) {
+}

--- a/src/main/java/com/gdg/Todak/diary/dto/DiarySummaryResponse.java
+++ b/src/main/java/com/gdg/Todak/diary/dto/DiarySummaryResponse.java
@@ -2,10 +2,11 @@ package com.gdg.Todak.diary.dto;
 
 import com.gdg.Todak.diary.Emotion;
 
-public record DiaryResponse(
+import java.time.LocalDate;
+
+public record DiarySummaryResponse(
         Long diaryId,
-        String title,
-        String content,
+        LocalDate createdAt,
         Emotion emotion
 ) {
 }

--- a/src/main/java/com/gdg/Todak/diary/dto/EmotionRequest.java
+++ b/src/main/java/com/gdg/Todak/diary/dto/EmotionRequest.java
@@ -1,8 +1,0 @@
-package com.gdg.Todak.diary.dto;
-
-import com.gdg.Todak.diary.Emotion;
-
-public record EmotionRequest(
-        Emotion emotion
-) {
-}

--- a/src/main/java/com/gdg/Todak/diary/entity/Diary.java
+++ b/src/main/java/com/gdg/Todak/diary/entity/Diary.java
@@ -2,9 +2,12 @@ package com.gdg.Todak.diary.entity;
 
 import com.gdg.Todak.common.domain.BaseEntity;
 import com.gdg.Todak.diary.Emotion;
+import com.gdg.Todak.member.domain.Member;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -16,18 +19,22 @@ public class Diary extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private String title;
     @Lob
     private String content;
+    @NotNull
     private Emotion emotion;
-//    @ManyToOne
-//    @JoinColumn(name = "member_id")
-//    @NotNull
-//    private Member member;
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    @NotNull
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Member member;
 
-    public void updateDiary(String title, String content, Emotion emotion) {
-        this.title = title;
+    public void updateDiary(String content, Emotion emotion) {
         this.content = content;
         this.emotion = emotion;
+    }
+
+    public boolean isWriter(Member member) {
+        return this.member.equals(member);
     }
 }

--- a/src/main/java/com/gdg/Todak/diary/exception/BadRequestException.java
+++ b/src/main/java/com/gdg/Todak/diary/exception/BadRequestException.java
@@ -1,0 +1,7 @@
+package com.gdg.Todak.diary.exception;
+
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/gdg/Todak/diary/exception/NotFoundException.java
+++ b/src/main/java/com/gdg/Todak/diary/exception/NotFoundException.java
@@ -1,0 +1,7 @@
+package com.gdg.Todak.diary.exception;
+
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/gdg/Todak/diary/exception/UnauthorizedException.java
+++ b/src/main/java/com/gdg/Todak/diary/exception/UnauthorizedException.java
@@ -1,0 +1,7 @@
+package com.gdg.Todak.diary.exception;
+
+public class UnauthorizedException extends RuntimeException {
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/gdg/Todak/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/gdg/Todak/diary/repository/DiaryRepository.java
@@ -1,12 +1,17 @@
 package com.gdg.Todak.diary.repository;
 
 import com.gdg.Todak.diary.entity.Diary;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import com.gdg.Todak.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.Instant;
+import java.util.List;
+
 @Repository
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
-    Page<Diary> findAll(Pageable pageable);
+
+    List<Diary> findByMemberAndCreatedAtBetween(Member member, Instant startPoint, Instant endPoint);
+
+    boolean existsByMemberAndCreatedAtBetween(Member member, Instant startOfDay, Instant endOfDay);
 }

--- a/src/main/java/com/gdg/Todak/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/gdg/Todak/diary/repository/DiaryRepository.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
@@ -14,4 +15,6 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
     List<Diary> findByMemberAndCreatedAtBetween(Member member, Instant startPoint, Instant endPoint);
 
     boolean existsByMemberAndCreatedAtBetween(Member member, Instant startOfDay, Instant endOfDay);
+
+    Optional<Diary> findByMemberAndContent(Member writer, String content);
 }

--- a/src/main/java/com/gdg/Todak/diary/service/DiaryService.java
+++ b/src/main/java/com/gdg/Todak/diary/service/DiaryService.java
@@ -2,6 +2,7 @@ package com.gdg.Todak.diary.service;
 
 import com.gdg.Todak.diary.dto.DiaryDetailResponse;
 import com.gdg.Todak.diary.dto.DiaryRequest;
+import com.gdg.Todak.diary.dto.DiarySearchRequest;
 import com.gdg.Todak.diary.dto.DiarySummaryResponse;
 import com.gdg.Todak.diary.entity.Diary;
 import com.gdg.Todak.diary.exception.BadRequestException;
@@ -53,8 +54,11 @@ public class DiaryService {
         diaryRepository.save(diary);
     }
 
-    public List<DiarySummaryResponse> getMySummaryByYearAndMonth(String memberName, int year, int month) {
+    public List<DiarySummaryResponse> getMySummaryByYearAndMonth(String memberName, DiarySearchRequest diarySearchRequest) {
         Member member = getMember(memberName);
+
+        int year = diarySearchRequest.year();
+        int month = diarySearchRequest.month();
 
         if (month < 1 || month > 12) {
             throw new BadRequestException("month의 범위는 1~12 입니다.");
@@ -74,9 +78,12 @@ public class DiaryService {
                 )).toList();
     }
 
-    public List<DiarySummaryResponse> getFriendSummaryByYearAndMonth(String memberName, String friendName, int year, int month) {
+    public List<DiarySummaryResponse> getFriendSummaryByYearAndMonth(String memberName, String friendName, DiarySearchRequest diarySearchRequest) {
         Member friendMember = memberRepository.findByUsername(friendName)
                 .orElseThrow(() -> new NotFoundException("friendName에 해당하는 멤버가 없습니다."));
+
+        int year = diarySearchRequest.year();
+        int month = diarySearchRequest.month();
 
         if (month < 1 || month > 12) {
             throw new BadRequestException("month의 범위는 1~12 입니다.");

--- a/src/main/java/com/gdg/Todak/friend/FriendStatus.java
+++ b/src/main/java/com/gdg/Todak/friend/FriendStatus.java
@@ -1,0 +1,7 @@
+package com.gdg.Todak.friend;
+
+public enum FriendStatus {
+    PENDING,
+    ACCEPTED,
+    DECLINED
+}

--- a/src/main/java/com/gdg/Todak/friend/controller/FriendController.java
+++ b/src/main/java/com/gdg/Todak/friend/controller/FriendController.java
@@ -27,6 +27,7 @@ public class FriendController {
 
     @Operation(summary = "친구 요청 보내기", description = "친구의 이름을 기반으로 친구요청합니다.")
     @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<Void> sendFriendRequest(@Parameter(hidden = true) @Login AuthenticateUser authenticateUser, @RequestBody FriendNameRequest friendNameRequest) {
         friendService.makeFriendRequest(authenticateUser.getUsername(), friendNameRequest);
         return ApiResponse.of(HttpStatus.CREATED, "친구 요청이 생성되었습니다.");

--- a/src/main/java/com/gdg/Todak/friend/controller/FriendController.java
+++ b/src/main/java/com/gdg/Todak/friend/controller/FriendController.java
@@ -77,8 +77,8 @@ public class FriendController {
 
     @Operation(summary = "친구요청수, 친구수 확인", description = "본인이 요청한 친구요청의 수, 본인의 친구의 수를 확인합니다.")
     @GetMapping("/count")
-    public ApiResponse<List<FriendCountResponse>> getOwnFriendCount(@Parameter(hidden = true) @Login AuthenticateUser authenticateUser) {
-        List<FriendCountResponse> friendCountResponses = friendService.getOwnFriendCountByStatus(authenticateUser.getUsername());
+    public ApiResponse<List<FriendCountResponse>> getMyFriendCount(@Parameter(hidden = true) @Login AuthenticateUser authenticateUser) {
+        List<FriendCountResponse> friendCountResponses = friendService.getMyFriendCountByStatus(authenticateUser.getUsername());
         return ApiResponse.ok(friendCountResponses);
     }
 }

--- a/src/main/java/com/gdg/Todak/friend/controller/FriendController.java
+++ b/src/main/java/com/gdg/Todak/friend/controller/FriendController.java
@@ -1,0 +1,83 @@
+package com.gdg.Todak.friend.controller;
+
+import com.gdg.Todak.common.domain.ApiResponse;
+import com.gdg.Todak.friend.dto.FriendCountResponse;
+import com.gdg.Todak.friend.dto.FriendNameRequest;
+import com.gdg.Todak.friend.dto.FriendRequestResponse;
+import com.gdg.Todak.friend.dto.FriendResponse;
+import com.gdg.Todak.friend.service.FriendService;
+import com.gdg.Todak.member.domain.AuthenticateUser;
+import com.gdg.Todak.member.resolver.Login;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/friend")
+@Tag(name = "친구", description = "친구 관련 API")
+public class FriendController {
+
+    private final FriendService friendService;
+
+    @Operation(summary = "친구 요청 보내기", description = "친구의 이름을 기반으로 친구요청합니다.")
+    @PostMapping
+    public ApiResponse<Void> sendFriendRequest(@Parameter(hidden = true) @Login AuthenticateUser authenticateUser, @RequestBody FriendNameRequest friendNameRequest) {
+        friendService.makeFriendRequest(authenticateUser.getUsername(), friendNameRequest);
+        return ApiResponse.of(HttpStatus.CREATED, "친구 요청이 생성되었습니다.");
+    }
+
+    @Operation(summary = "친구 확인", description = "본인의 친구들을 확인합니다.")
+    @GetMapping
+    public ApiResponse<List<FriendResponse>> getAllFriends(@Parameter(hidden = true) @Login AuthenticateUser authenticateUser) {
+        List<FriendResponse> friendResponses = friendService.getAllFriend(authenticateUser.getUsername());
+        return ApiResponse.ok(friendResponses);
+    }
+
+    @Operation(summary = "대기중인 친구 요청들 확인", description = "본인에게 온 친구 요청 대기 목록을 확인합니다.")
+    @GetMapping("/pending")
+    public ApiResponse<List<FriendRequestResponse>> getAllPendingFriendRequest(@Parameter(hidden = true) @Login AuthenticateUser authenticateUser) {
+        List<FriendRequestResponse> friendRequestResponses = friendService.getAllFriendRequests(authenticateUser.getUsername());
+        return ApiResponse.ok(friendRequestResponses);
+    }
+
+    @Operation(summary = "거절한 친구 요청들 확인", description = "본인에게 온 친구 요청 중 거절한 요청 목록을 확인합니다.")
+    @GetMapping("/declined")
+    public ApiResponse<List<FriendRequestResponse>> getAllDeclinedFriendRequest(@Parameter(hidden = true) @Login AuthenticateUser authenticateUser) {
+        List<FriendRequestResponse> friendRequestResponses = friendService.getAllDeclinedFriends(authenticateUser.getUsername());
+        return ApiResponse.ok(friendRequestResponses);
+    }
+
+    @Operation(summary = "친구 요청 수락", description = "친구 요청을 수락합니다.")
+    @PutMapping("/accept/{friendRequestId}")
+    public ApiResponse<Void> acceptFriendRequest(@Parameter(hidden = true) @Login AuthenticateUser authenticateUser, @PathVariable Long friendRequestId) {
+        friendService.acceptFriendRequest(authenticateUser.getUsername(), friendRequestId);
+        return ApiResponse.of(HttpStatus.OK, "친구 요청이 수락되었습니다.");
+    }
+
+    @Operation(summary = "친구 요청 거절", description = "친구 요청을 거절합니다.")
+    @PutMapping("/decline/{friendRequestId}")
+    public ApiResponse<Void> declineFriendRequest(@Parameter(hidden = true) @Login AuthenticateUser authenticateUser, @PathVariable Long friendRequestId) {
+        friendService.declineFriendRequest(authenticateUser.getUsername(), friendRequestId);
+        return ApiResponse.of(HttpStatus.OK, "친구 요청을 거절하였습니다.");
+    }
+
+    @Operation(summary = "친구 또는 친구요청 삭제", description = "친구를 삭제합니다.")
+    @DeleteMapping("/{friendRequestId}")
+    public ApiResponse<Void> deleteFriend(@Parameter(hidden = true) @Login AuthenticateUser authenticateUser, @PathVariable Long friendRequestId) {
+        friendService.deleteFriend(authenticateUser.getUsername(), friendRequestId);
+        return ApiResponse.of(HttpStatus.OK, "친구/친구요청을 삭제하였습니다.");
+    }
+
+    @Operation(summary = "친구요청수, 친구수 확인", description = "본인이 요청한 친구요청의 수, 본인의 친구의 수를 확인합니다.")
+    @GetMapping("/count")
+    public ApiResponse<List<FriendCountResponse>> getOwnFriendCount(@Parameter(hidden = true) @Login AuthenticateUser authenticateUser) {
+        List<FriendCountResponse> friendCountResponses = friendService.getOwnFriendCountByStatus(authenticateUser.getUsername());
+        return ApiResponse.ok(friendCountResponses);
+    }
+}

--- a/src/main/java/com/gdg/Todak/friend/controller/advice/FriendControllerAdvice.java
+++ b/src/main/java/com/gdg/Todak/friend/controller/advice/FriendControllerAdvice.java
@@ -1,0 +1,51 @@
+package com.gdg.Todak.friend.controller.advice;
+
+import com.gdg.Todak.common.domain.ApiResponse;
+import com.gdg.Todak.friend.exception.BadRequestException;
+import com.gdg.Todak.friend.exception.NotFoundException;
+import com.gdg.Todak.member.exception.UnauthorizedException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(basePackages = "com.gdg.Todak.friend")
+public class FriendControllerAdvice {
+
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    @ExceptionHandler(UnauthorizedException.class)
+    public ApiResponse<Exception> loginFailed(UnauthorizedException e) {
+        return ApiResponse.of(
+                HttpStatus.UNAUTHORIZED,
+                e.getMessage()
+        );
+    }
+
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(NotFoundException.class)
+    public ApiResponse<Exception> encryptionFailed(NotFoundException e) {
+        return ApiResponse.of(
+                HttpStatus.NOT_FOUND,
+                e.getMessage()
+        );
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(BadRequestException.class)
+    public ApiResponse<Object> bindException(BadRequestException e) {
+        return ApiResponse.of(
+                HttpStatus.BAD_REQUEST,
+                e.getMessage()
+        );
+    }
+
+    @ResponseStatus(HttpStatus.CONFLICT)
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ApiResponse<Object> handleDataIntegrityViolationException(DataIntegrityViolationException e) {
+        return ApiResponse.of(
+                HttpStatus.CONFLICT,
+                e.getMostSpecificCause().getMessage()
+        );
+    }
+}

--- a/src/main/java/com/gdg/Todak/friend/dto/FriendCountResponse.java
+++ b/src/main/java/com/gdg/Todak/friend/dto/FriendCountResponse.java
@@ -1,0 +1,9 @@
+package com.gdg.Todak.friend.dto;
+
+import com.gdg.Todak.friend.FriendStatus;
+
+public record FriendCountResponse(
+        FriendStatus friendStatus,
+        long count
+) {
+}

--- a/src/main/java/com/gdg/Todak/friend/dto/FriendNameRequest.java
+++ b/src/main/java/com/gdg/Todak/friend/dto/FriendNameRequest.java
@@ -1,0 +1,6 @@
+package com.gdg.Todak.friend.dto;
+
+public record FriendNameRequest(
+        String friendName
+) {
+}

--- a/src/main/java/com/gdg/Todak/friend/dto/FriendRequestResponse.java
+++ b/src/main/java/com/gdg/Todak/friend/dto/FriendRequestResponse.java
@@ -1,0 +1,8 @@
+package com.gdg.Todak.friend.dto;
+
+public record FriendRequestResponse(
+        Long friendRequestId,
+        String requesterName,
+        String accepterName
+) {
+}

--- a/src/main/java/com/gdg/Todak/friend/dto/FriendResponse.java
+++ b/src/main/java/com/gdg/Todak/friend/dto/FriendResponse.java
@@ -1,0 +1,7 @@
+package com.gdg.Todak.friend.dto;
+
+public record FriendResponse(
+        Long friendRequestId,
+        String friendName
+) {
+}

--- a/src/main/java/com/gdg/Todak/friend/entity/Friend.java
+++ b/src/main/java/com/gdg/Todak/friend/entity/Friend.java
@@ -6,6 +6,8 @@ import com.gdg.Todak.member.domain.Member;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Builder
@@ -20,10 +22,12 @@ public class Friend {
     @NotNull
     @ManyToOne
     @JoinColumn(name = "requester_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member requester;
     @NotNull
     @ManyToOne
     @JoinColumn(name = "accepter_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member accepter;
     @NotNull
     private FriendStatus friendStatus;

--- a/src/main/java/com/gdg/Todak/friend/entity/Friend.java
+++ b/src/main/java/com/gdg/Todak/friend/entity/Friend.java
@@ -1,0 +1,52 @@
+package com.gdg.Todak.friend.entity;
+
+import com.gdg.Todak.friend.FriendStatus;
+import com.gdg.Todak.friend.exception.BadRequestException;
+import com.gdg.Todak.member.domain.Member;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class Friend {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @NotNull
+    @ManyToOne
+    @JoinColumn(name = "requester_id")
+    private Member requester;
+    @NotNull
+    @ManyToOne
+    @JoinColumn(name = "accepter_id")
+    private Member accepter;
+    @NotNull
+    private FriendStatus friendStatus;
+
+    public boolean checkMemberIsNotAccepter(Member member) {
+        return !this.accepter.equals(member);
+    }
+
+    public boolean checkMemberIsNotRequester(Member member) {
+        return !this.requester.equals(member);
+    }
+
+    public void acceptFriendRequest() {
+        if (!this.friendStatus.equals(FriendStatus.PENDING)) {
+            throw new BadRequestException("대기중인 친구 요청이 아닙니다.");
+        }
+        this.friendStatus = FriendStatus.ACCEPTED;
+    }
+
+    public void declinedFriendRequest() {
+        if (!this.friendStatus.equals(FriendStatus.PENDING)) {
+            throw new BadRequestException("대기중인 친구 요청이 아닙니다.");
+        }
+        this.friendStatus = FriendStatus.DECLINED;
+    }
+}

--- a/src/main/java/com/gdg/Todak/friend/exception/BadRequestException.java
+++ b/src/main/java/com/gdg/Todak/friend/exception/BadRequestException.java
@@ -1,0 +1,7 @@
+package com.gdg.Todak.friend.exception;
+
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/gdg/Todak/friend/exception/NotFoundException.java
+++ b/src/main/java/com/gdg/Todak/friend/exception/NotFoundException.java
@@ -1,0 +1,7 @@
+package com.gdg.Todak.friend.exception;
+
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/gdg/Todak/friend/exception/UnauthorizedException.java
+++ b/src/main/java/com/gdg/Todak/friend/exception/UnauthorizedException.java
@@ -1,0 +1,7 @@
+package com.gdg.Todak.friend.exception;
+
+public class UnauthorizedException extends RuntimeException {
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/gdg/Todak/friend/repository/FriendRepository.java
+++ b/src/main/java/com/gdg/Todak/friend/repository/FriendRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface FriendRepository extends JpaRepository<Friend, Long> {
@@ -22,4 +23,6 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
 
     @Query("SELECT COUNT(f) FROM Friend f WHERE f.accepter = :member AND f.friendStatus IN :statuses")
     long countByAccepterAndStatusIn(@Param("member") Member member, @Param("statuses") List<FriendStatus> statuses);
+
+    Optional<Friend> findByRequesterAndAccepter(Member requester, Member accepter);
 }

--- a/src/main/java/com/gdg/Todak/friend/repository/FriendRepository.java
+++ b/src/main/java/com/gdg/Todak/friend/repository/FriendRepository.java
@@ -1,0 +1,25 @@
+package com.gdg.Todak.friend.repository;
+
+import com.gdg.Todak.friend.FriendStatus;
+import com.gdg.Todak.friend.entity.Friend;
+import com.gdg.Todak.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface FriendRepository extends JpaRepository<Friend, Long> {
+    boolean existsByRequesterAndAccepter(Member requester, Member accepter);
+
+    List<Friend> findAllByAccepterUsernameAndFriendStatusOrRequesterUsernameAndFriendStatus
+            (String accepterName, FriendStatus friendStatus1, String requesterName, FriendStatus friendStatus2);
+
+    @Query("SELECT COUNT(f) FROM Friend f WHERE f.requester = :member AND f.friendStatus IN :statuses")
+    long countByRequesterAndStatusIn(@Param("member") Member member, @Param("statuses") List<FriendStatus> statuses);
+
+    @Query("SELECT COUNT(f) FROM Friend f WHERE f.accepter = :member AND f.friendStatus IN :statuses")
+    long countByAccepterAndStatusIn(@Param("member") Member member, @Param("statuses") List<FriendStatus> statuses);
+}

--- a/src/main/java/com/gdg/Todak/friend/service/FriendService.java
+++ b/src/main/java/com/gdg/Todak/friend/service/FriendService.java
@@ -8,6 +8,7 @@ import com.gdg.Todak.friend.dto.FriendResponse;
 import com.gdg.Todak.friend.entity.Friend;
 import com.gdg.Todak.friend.exception.BadRequestException;
 import com.gdg.Todak.friend.exception.NotFoundException;
+import com.gdg.Todak.friend.exception.UnauthorizedException;
 import com.gdg.Todak.friend.repository.FriendRepository;
 import com.gdg.Todak.member.domain.Member;
 import com.gdg.Todak.member.repository.MemberRepository;
@@ -109,7 +110,7 @@ public class FriendService {
                 .orElseThrow(() -> new NotFoundException("friendRequestId에 해당하는 친구요청이 없습니다."));
 
         if (friendRequest.checkMemberIsNotAccepter(member)) {
-            throw new BadRequestException("친구 요청을 수락할 권한이 없습니다. 요청받은 사람만 수락할 수 있습니다.");
+            throw new UnauthorizedException("친구 요청을 수락할 권한이 없습니다. 요청받은 사람만 수락할 수 있습니다.");
         }
 
         friendRequest.acceptFriendRequest();
@@ -124,7 +125,7 @@ public class FriendService {
                 .orElseThrow(() -> new NotFoundException("friendRequestId에 해당하는 친구요청이 없습니다."));
 
         if (friendRequest.checkMemberIsNotAccepter(member)) {
-            throw new BadRequestException("친구 요청을 수락할 권한이 없습니다. 요청받은 사람만 수락할 수 있습니다.");
+            throw new UnauthorizedException("친구 요청을 수락할 권한이 없습니다. 요청받은 사람만 수락할 수 있습니다.");
         }
 
         friendRequest.declinedFriendRequest();
@@ -139,7 +140,7 @@ public class FriendService {
                 .orElseThrow(() -> new NotFoundException("friendRequestId에 해당하는 친구요청이 없습니다."));
 
         if (friendRequest.checkMemberIsNotRequester(member) && friendRequest.checkMemberIsNotAccepter(member)) {
-            throw new BadRequestException("친구를 삭제할 권한이 없습니다. 당사자들만 삭제할 수 있습니다.");
+            throw new UnauthorizedException("친구를 삭제할 권한이 없습니다. 당사자들만 삭제할 수 있습니다.");
         }
 
         friendRepository.deleteById(friendRequestId);

--- a/src/main/java/com/gdg/Todak/friend/service/FriendService.java
+++ b/src/main/java/com/gdg/Todak/friend/service/FriendService.java
@@ -1,0 +1,162 @@
+package com.gdg.Todak.friend.service;
+
+import com.gdg.Todak.friend.FriendStatus;
+import com.gdg.Todak.friend.dto.FriendCountResponse;
+import com.gdg.Todak.friend.dto.FriendNameRequest;
+import com.gdg.Todak.friend.dto.FriendRequestResponse;
+import com.gdg.Todak.friend.dto.FriendResponse;
+import com.gdg.Todak.friend.entity.Friend;
+import com.gdg.Todak.friend.exception.BadRequestException;
+import com.gdg.Todak.friend.exception.NotFoundException;
+import com.gdg.Todak.friend.repository.FriendRepository;
+import com.gdg.Todak.member.domain.Member;
+import com.gdg.Todak.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class FriendService {
+
+    private final FriendRepository friendRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void makeFriendRequest(String memberName, FriendNameRequest friendNameRequest) {
+        Member requesterMember = memberRepository.findByUsername(memberName)
+                .orElseThrow(() -> new NotFoundException("memberName에 해당하는 멤버가 없습니다."));
+        Member accepterMember = memberRepository.findByUsername(friendNameRequest.friendName())
+                .orElseThrow(() -> new NotFoundException("friendName에 해당하는 멤버가 없습니다."));
+
+        if (friendRepository.existsByRequesterAndAccepter(requesterMember, accepterMember) || friendRepository.existsByRequesterAndAccepter(accepterMember, requesterMember)) {
+            throw new BadRequestException("이미 친구이거나, 대기 또는 거절된 친구요청이 존재합니다.");
+        }
+
+        if (requesterMember.equals(accepterMember)) {
+            throw new BadRequestException("본인에게는 친구 요청을 할 수 없습니다");
+        }
+
+        long requesterFriendCount = friendRepository.countByRequesterAndStatusIn(requesterMember, List.of(FriendStatus.PENDING, FriendStatus.ACCEPTED));
+        if (requesterFriendCount >= 20) {
+            throw new BadRequestException("친구 요청 개수를 초과하였습니다. (최대 20개)");
+        }
+
+        long accepterFriendCount = friendRepository.countByAccepterAndStatusIn(accepterMember, List.of(FriendStatus.PENDING, FriendStatus.ACCEPTED));
+        if (accepterFriendCount >= 20) {
+            throw new BadRequestException("상대방이 더 이상 친구 요청을 받을 수 없습니다. (최대 20개)");
+        }
+
+        friendRepository.save(Friend.builder()
+                .requester(requesterMember)
+                .accepter(accepterMember)
+                .friendStatus(FriendStatus.PENDING)
+                .build());
+    }
+
+    @Transactional(readOnly = true)
+    public List<FriendResponse> getAllFriend(String memberName) {
+        return friendRepository.findAllByAccepterUsernameAndFriendStatusOrRequesterUsernameAndFriendStatus(memberName, FriendStatus.ACCEPTED, memberName, FriendStatus.ACCEPTED)
+                .stream().map(friend -> {
+                    if (friend.getRequester().getUsername().equals(memberName)) {
+                        return new FriendResponse(
+                                friend.getId(),
+                                friend.getAccepter().getUsername()
+                        );
+                    } else {
+                        return new FriendResponse(
+                                friend.getId(),
+                                friend.getRequester().getUsername()
+                        );
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public List<FriendRequestResponse> getAllDeclinedFriends(String memberName) {
+        return friendRepository.findAllByAccepterUsernameAndFriendStatusOrRequesterUsernameAndFriendStatus(memberName, FriendStatus.DECLINED, memberName, FriendStatus.DECLINED)
+                .stream().map(
+                        Friend -> new FriendRequestResponse(
+                                Friend.getId(),
+                                Friend.getRequester().getUsername(),
+                                Friend.getAccepter().getUsername()
+                        ))
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public List<FriendRequestResponse> getAllFriendRequests(String memberName) {
+        return friendRepository.findAllByAccepterUsernameAndFriendStatusOrRequesterUsernameAndFriendStatus(memberName, FriendStatus.PENDING, memberName, FriendStatus.PENDING)
+                .stream().map(
+                        Friend -> new FriendRequestResponse(
+                                Friend.getId(),
+                                Friend.getRequester().getUsername(),
+                                Friend.getAccepter().getUsername()
+                        ))
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void acceptFriendRequest(String memberName, Long friendRequestId) {
+        Member member = memberRepository.findByUsername(memberName)
+                .orElseThrow(() -> new NotFoundException("memberName에 해당하는 멤버가 없습니다."));
+
+        Friend friendRequest = friendRepository.findById(friendRequestId)
+                .orElseThrow(() -> new NotFoundException("friendRequestId에 해당하는 친구요청이 없습니다."));
+
+        if (friendRequest.checkMemberIsNotAccepter(member)) {
+            throw new BadRequestException("친구 요청을 수락할 권한이 없습니다. 요청받은 사람만 수락할 수 있습니다.");
+        }
+
+        friendRequest.acceptFriendRequest();
+    }
+
+    @Transactional
+    public void declineFriendRequest(String memberName, Long friendRequestId) {
+        Member member = memberRepository.findByUsername(memberName)
+                .orElseThrow(() -> new NotFoundException("memberName에 해당하는 멤버가 없습니다."));
+
+        Friend friendRequest = friendRepository.findById(friendRequestId)
+                .orElseThrow(() -> new NotFoundException("friendRequestId에 해당하는 친구요청이 없습니다."));
+
+        if (friendRequest.checkMemberIsNotAccepter(member)) {
+            throw new BadRequestException("친구 요청을 수락할 권한이 없습니다. 요청받은 사람만 수락할 수 있습니다.");
+        }
+
+        friendRequest.declinedFriendRequest();
+    }
+
+    @Transactional
+    public void deleteFriend(String memberName, Long friendRequestId) {
+        Member member = memberRepository.findByUsername(memberName)
+                .orElseThrow(() -> new NotFoundException("memberName에 해당하는 멤버가 없습니다."));
+
+        Friend friendRequest = friendRepository.findById(friendRequestId)
+                .orElseThrow(() -> new NotFoundException("friendRequestId에 해당하는 친구요청이 없습니다."));
+
+        if (friendRequest.checkMemberIsNotRequester(member) && friendRequest.checkMemberIsNotAccepter(member)) {
+            throw new BadRequestException("친구를 삭제할 권한이 없습니다. 당사자들만 삭제할 수 있습니다.");
+        }
+
+        friendRepository.deleteById(friendRequestId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<FriendCountResponse> getOwnFriendCountByStatus(String memberName) {
+        Member member = memberRepository.findByUsername(memberName)
+                .orElseThrow(() -> new NotFoundException("memberName에 해당하는 멤버가 없습니다."));
+
+        long PendingFriendCount = friendRepository.countByRequesterAndStatusIn(member, List.of(FriendStatus.PENDING));
+        long AcceptedFriendCount = friendRepository.countByRequesterAndStatusIn(member, List.of(FriendStatus.ACCEPTED))
+                + friendRepository.countByAccepterAndStatusIn(member, List.of(FriendStatus.ACCEPTED));
+
+        return List.of(
+                new FriendCountResponse(FriendStatus.PENDING, PendingFriendCount),
+                new FriendCountResponse(FriendStatus.ACCEPTED, AcceptedFriendCount)
+        );
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,12 +1,12 @@
 spring.application.name=Todak
 spring.profiles.active=dev
 
-# MySQL ?????? ??
+# MySQL
 spring.datasource.url=jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
 spring.datasource.username=${MYSQL_USER}
 spring.datasource.password=${MYSQL_PASSWORD}
 
-# JPA ??
+# JPA
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=update

--- a/src/test/java/com/gdg/Todak/diary/controller/DiaryControllerTest.java
+++ b/src/test/java/com/gdg/Todak/diary/controller/DiaryControllerTest.java
@@ -1,0 +1,194 @@
+package com.gdg.Todak.diary.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gdg.Todak.diary.Emotion;
+import com.gdg.Todak.diary.dto.DiaryDetailResponse;
+import com.gdg.Todak.diary.dto.DiaryRequest;
+import com.gdg.Todak.diary.dto.DiarySummaryResponse;
+import com.gdg.Todak.diary.service.DiaryService;
+import com.gdg.Todak.member.Interceptor.LoginCheckInterceptor;
+import com.gdg.Todak.member.domain.AuthenticateUser;
+import com.gdg.Todak.member.domain.Role;
+import com.gdg.Todak.member.resolver.LoginMemberArgumentResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(DiaryController.class)
+class DiaryControllerTest {
+
+    private final String token = "testToken";
+
+    @MockitoBean
+    private DiaryService diaryService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private WebApplicationContext context;
+    @MockitoBean
+    private LoginCheckInterceptor loginCheckInterceptor;
+
+    @MockitoBean
+    private LoginMemberArgumentResolver loginMemberArgumentResolver;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        when(loginCheckInterceptor.preHandle(any(), any(), any())).thenReturn(true);
+
+        String username = "testUser";
+        AuthenticateUser authenticateUser = new AuthenticateUser(username, Set.of(Role.USER));
+
+        when(loginMemberArgumentResolver.supportsParameter(any())).thenReturn(true);
+        when(loginMemberArgumentResolver.resolveArgument(any(), any(), any(), any())).thenReturn(authenticateUser);
+
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .build();
+    }
+
+    @Test
+    @DisplayName("일기 작성 테스트")
+    void writeDiaryTest() throws Exception {
+        // given
+        DiaryRequest request = new DiaryRequest("오늘은 좋은 하루였다.", Emotion.HAPPY);
+        doNothing().when(diaryService).writeDiary(anyString(), any(DiaryRequest.class));
+
+        // when
+        mockMvc.perform(post("/api/v1/diary")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+
+                // then
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.message").value("작성되었습니다."));
+    }
+
+    @Test
+    @DisplayName("본인의 년/월에 해당하는 모든 일기 요약 조회 테스트")
+    void getOwnAllDiaryTest() throws Exception {
+        // given
+        List<DiarySummaryResponse> responses = Arrays.asList(
+                new DiarySummaryResponse(1L, LocalDate.of(2025, 3, 1), Emotion.HAPPY),
+                new DiarySummaryResponse(2L, LocalDate.of(2025, 3, 2), Emotion.SAD)
+        );
+        when(diaryService.getOwnSummaryByYearAndMonth(anyString(), anyInt(), anyInt())).thenReturn(responses);
+
+        // when
+        mockMvc.perform(get("/api/v1/diary/own/2025/3")
+                        .header("Authorization", "Bearer " + token))
+
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].diaryId").value(1))
+                .andExpect(jsonPath("$.data[0].createdAt").value("2025-03-01"))
+                .andExpect(jsonPath("$.data[0].emotion").value("HAPPY"))
+                .andExpect(jsonPath("$.data[1].diaryId").value(2))
+                .andExpect(jsonPath("$.data[1].createdAt").value("2025-03-02"))
+                .andExpect(jsonPath("$.data[1].emotion").value("SAD"));
+    }
+
+    @Test
+    @DisplayName("친구의 년/월에 해당하는 모든 일기 요약 조회 테스트")
+    void getAllDiaryByFriendTest() throws Exception {
+        // given
+        List<DiarySummaryResponse> responses = Arrays.asList(
+                new DiarySummaryResponse(1L, LocalDate.of(2025, 3, 1), Emotion.HAPPY),
+                new DiarySummaryResponse(2L, LocalDate.of(2025, 3, 2), Emotion.SAD)
+        );
+        when(diaryService.getFriendSummaryByYearAndMonth(anyString(), anyString(), anyInt(), anyInt())).thenReturn(responses);
+
+        // when
+        mockMvc.perform(get("/api/v1/diary/friend/friendName/2025/3")
+                        .header("Authorization", "Bearer " + token))
+
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].diaryId").value(1))
+                .andExpect(jsonPath("$.data[0].createdAt").value("2025-03-01"))
+                .andExpect(jsonPath("$.data[0].emotion").value("HAPPY"))
+                .andExpect(jsonPath("$.data[1].diaryId").value(2))
+                .andExpect(jsonPath("$.data[1].createdAt").value("2025-03-02"))
+                .andExpect(jsonPath("$.data[1].emotion").value("SAD"));
+    }
+
+    @Test
+    @DisplayName("일기 상세보기 테스트")
+    void getDiaryTest() throws Exception {
+        // given
+        DiaryDetailResponse response = new DiaryDetailResponse(1L, LocalDateTime.of(2025, 3, 1, 12, 12, 0, 0), "오늘은 기쁜 날이다", Emotion.HAPPY, true);
+        when(diaryService.readDiary(anyString(), anyLong())).thenReturn(response);
+
+        // when
+        mockMvc.perform(get("/api/v1/diary/1")
+                        .header("Authorization", "Bearer " + token))
+
+                // then
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andExpect(jsonPath("$.data.diaryId").value(1))
+                .andExpect(jsonPath("$.data.createdAt").value("2025-03-01T12:12:00"))
+                .andExpect(jsonPath("$.data.content").value("오늘은 기쁜 날이다"))
+                .andExpect(jsonPath("$.data.emotion").value("HAPPY"))
+                .andExpect(jsonPath("$.data.isWriter").value(true));
+    }
+
+    @Test
+    @DisplayName("일기 수정 테스트")
+    void updateDiaryTest() throws Exception {
+        // given
+        DiaryRequest request = new DiaryRequest("오늘은 슬펐다.", Emotion.SAD);
+        doNothing().when(diaryService).updateDiary(anyString(), anyLong(), any(DiaryRequest.class));
+
+        // when
+        mockMvc.perform(put("/api/v1/diary/1")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("수정되었습니다."));
+    }
+
+    @Test
+    @DisplayName("일기 삭제 테스트")
+    void deleteDiaryTest() throws Exception {
+        // given
+        doNothing().when(diaryService).deleteDiary(anyString(), anyLong());
+
+        // when
+        mockMvc.perform(delete("/api/v1/diary/1")
+                        .header("Authorization", "Bearer " + token))
+
+                // then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("삭제되었습니다."));
+    }
+}

--- a/src/test/java/com/gdg/Todak/diary/controller/DiaryControllerTest.java
+++ b/src/test/java/com/gdg/Todak/diary/controller/DiaryControllerTest.java
@@ -98,10 +98,10 @@ class DiaryControllerTest {
                 new DiarySummaryResponse(1L, LocalDate.of(2025, 3, 1), Emotion.HAPPY),
                 new DiarySummaryResponse(2L, LocalDate.of(2025, 3, 2), Emotion.SAD)
         );
-        when(diaryService.getOwnSummaryByYearAndMonth(anyString(), anyInt(), anyInt())).thenReturn(responses);
+        when(diaryService.getMySummaryByYearAndMonth(anyString(), anyInt(), anyInt())).thenReturn(responses);
 
         // when
-        mockMvc.perform(get("/api/v1/diary/own/2025/3")
+        mockMvc.perform(get("/api/v1/diary/me/2025/3")
                         .header("Authorization", "Bearer " + token))
 
                 // then

--- a/src/test/java/com/gdg/Todak/diary/controller/DiaryControllerTest.java
+++ b/src/test/java/com/gdg/Todak/diary/controller/DiaryControllerTest.java
@@ -18,8 +18,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -49,8 +47,6 @@ class DiaryControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @Autowired
-    private WebApplicationContext context;
     @MockitoBean
     private LoginCheckInterceptor loginCheckInterceptor;
 
@@ -66,10 +62,6 @@ class DiaryControllerTest {
 
         when(loginMemberArgumentResolver.supportsParameter(any())).thenReturn(true);
         when(loginMemberArgumentResolver.resolveArgument(any(), any(), any(), any())).thenReturn(authenticateUser);
-
-        mockMvc = MockMvcBuilders
-                .webAppContextSetup(context)
-                .build();
     }
 
     @Test

--- a/src/test/java/com/gdg/Todak/diary/controller/DiaryControllerTest.java
+++ b/src/test/java/com/gdg/Todak/diary/controller/DiaryControllerTest.java
@@ -90,7 +90,7 @@ class DiaryControllerTest {
                 new DiarySummaryResponse(1L, LocalDate.of(2025, 3, 1), Emotion.HAPPY),
                 new DiarySummaryResponse(2L, LocalDate.of(2025, 3, 2), Emotion.SAD)
         );
-        when(diaryService.getMySummaryByYearAndMonth(anyString(), anyInt(), anyInt())).thenReturn(responses);
+        when(diaryService.getMySummaryByYearAndMonth(anyString(), any())).thenReturn(responses);
 
         // when
         mockMvc.perform(get("/api/v1/diary/me/2025/3")
@@ -114,7 +114,7 @@ class DiaryControllerTest {
                 new DiarySummaryResponse(1L, LocalDate.of(2025, 3, 1), Emotion.HAPPY),
                 new DiarySummaryResponse(2L, LocalDate.of(2025, 3, 2), Emotion.SAD)
         );
-        when(diaryService.getFriendSummaryByYearAndMonth(anyString(), anyString(), anyInt(), anyInt())).thenReturn(responses);
+        when(diaryService.getFriendSummaryByYearAndMonth(anyString(), anyString(), any())).thenReturn(responses);
 
         // when
         mockMvc.perform(get("/api/v1/diary/friend/friendName/2025/3")

--- a/src/test/java/com/gdg/Todak/diary/entity/DiaryTest.java
+++ b/src/test/java/com/gdg/Todak/diary/entity/DiaryTest.java
@@ -1,0 +1,58 @@
+package com.gdg.Todak.diary.entity;
+
+import com.gdg.Todak.diary.Emotion;
+import com.gdg.Todak.member.domain.Member;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DiaryTest {
+
+    private Diary diary;
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        member = new Member("user1", "test1", "test1", "test1");
+        diary = Diary.builder()
+                .content("오늘 하루도 힘들었다.")
+                .emotion(Emotion.SAD)
+                .member(member)
+                .build();
+    }
+
+    @DisplayName("Diary 객체 생성 테스트")
+    @Test
+    void constructorTest() {
+        assertThat(diary).isNotNull();
+        assertThat(diary.getContent()).isEqualTo("오늘 하루도 힘들었다.");
+        assertThat(diary.getEmotion()).isEqualTo(Emotion.SAD);
+        assertThat(diary.getMember()).isEqualTo(member);
+    }
+
+    @DisplayName("일기를 수정하면 내용과 감정 상태가 변경되어야 한다")
+    @Test
+    void updateDiaryTest() {
+        // when
+        diary.updateDiary("오늘은 기분이 좋다!", Emotion.HAPPY);
+
+        // then
+        assertThat(diary.getContent()).isEqualTo("오늘은 기분이 좋다!");
+        assertThat(diary.getEmotion()).isEqualTo(Emotion.HAPPY);
+    }
+
+    @DisplayName("일기의 작성자인 경우 isWriter가 true를 반환해야 한다")
+    @Test
+    void isWriterTest() {
+        assertThat(diary.isWriter(member)).isTrue();
+    }
+
+    @DisplayName("일기의 작성자가 아닌 경우 isWriter가 false를 반환해야 한다")
+    @Test
+    void isWriter_notWriterTest() {
+        Member otherMember = new Member("user2", "test2", "test2", "test2");
+        assertThat(diary.isWriter(otherMember)).isFalse();
+    }
+}

--- a/src/test/java/com/gdg/Todak/diary/repository/DiaryRepositoryTest.java
+++ b/src/test/java/com/gdg/Todak/diary/repository/DiaryRepositoryTest.java
@@ -1,0 +1,99 @@
+package com.gdg.Todak.diary.repository;
+
+import com.gdg.Todak.diary.Emotion;
+import com.gdg.Todak.diary.entity.Diary;
+import com.gdg.Todak.member.domain.Member;
+import com.gdg.Todak.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class DiaryRepositoryTest {
+
+    @Autowired
+    DiaryRepository diaryRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @DisplayName("Diary 객체 정상 저장 테스트")
+    @Test
+    void diarySaveTest() {
+        // given
+        Member member = memberRepository.save(new Member("user1", "test1", "test1", "test1"));
+        Diary diary = Diary.builder()
+                .member(member)
+                .content("오늘 하루도 행복했다.")
+                .emotion(Emotion.HAPPY)
+                .build();
+
+        // when
+        Diary savedDiary = diaryRepository.save(diary);
+
+        // then
+        assertThat(savedDiary.getId()).isNotNull();
+        assertThat(savedDiary.getMember().getId()).isNotNull();
+        assertThat(savedDiary.getContent()).isEqualTo("오늘 하루도 행복했다.");
+    }
+
+    @DisplayName("findByMemberAndCreatedAtBetween() 테스트 - 특정 기간의 일기 조회")
+    @Test
+    void findByMemberAndCreatedAtBetweenTest() {
+        // given
+        Member member = memberRepository.save(new Member("user1", "test1", "test1", "test1"));
+        Instant start = Instant.now().minusSeconds(86400);
+        Instant end = Instant.now().plusSeconds(86400);
+
+        Diary yesterdayDiary = Diary.builder().member(member).content("어제의 일기").emotion(Emotion.HAPPY).build();
+        ReflectionTestUtils.setField(yesterdayDiary, "createdAt", start);
+        diaryRepository.save(yesterdayDiary);
+
+        Diary todayDiary = Diary.builder().member(member).content("오늘의 일기").emotion(Emotion.HAPPY).build();
+        ReflectionTestUtils.setField(todayDiary, "createdAt", Instant.now());
+        diaryRepository.save(todayDiary);
+
+        Diary tomorrowDiary = Diary.builder().member(member).content("내일의 일기").emotion(Emotion.HAPPY).build();
+        ReflectionTestUtils.setField(tomorrowDiary, "createdAt", end);
+        diaryRepository.save(tomorrowDiary);
+
+        // when
+        List<Diary> diaries = diaryRepository.findByMemberAndCreatedAtBetween(member, start, end);
+
+        // then
+        assertThat(diaries).hasSize(3);
+    }
+
+    @DisplayName("existsByMemberAndCreatedAtBetween() 테스트 - 특정 기간에 작성된 일기 존재 여부 확인")
+    @Test
+    void existsByMemberAndCreatedAtBetweenTest() {
+        // given
+        Member member = memberRepository.save(new Member("user1", "test1", "test1", "test1"));
+        Instant startOfDay = Instant.now().minusSeconds(43200);
+        Instant endOfDay = Instant.now().plusSeconds(43200);
+
+        Diary diary = Diary.builder()
+                .member(member)
+                .content("오늘 하루도 행복했다.")
+                .emotion(Emotion.HAPPY)
+                .build();
+        ReflectionTestUtils.setField(diary, "createdAt", Instant.now());
+
+        diaryRepository.save(diary);
+
+        // when
+        boolean exists = diaryRepository.existsByMemberAndCreatedAtBetween(member, startOfDay, endOfDay);
+
+        // then
+        assertThat(exists).isTrue();
+    }
+}

--- a/src/test/java/com/gdg/Todak/diary/service/DiaryServiceTest.java
+++ b/src/test/java/com/gdg/Todak/diary/service/DiaryServiceTest.java
@@ -142,7 +142,7 @@ class DiaryServiceTest {
 
 
         // when
-        List<DiarySummaryResponse> summaries = diaryService.getOwnSummaryByYearAndMonth(writer.getUsername(), year, month);
+        List<DiarySummaryResponse> summaries = diaryService.getMySummaryByYearAndMonth(writer.getUsername(), year, month);
 
         // then
         assertThat(summaries).hasSize(2);

--- a/src/test/java/com/gdg/Todak/diary/service/DiaryServiceTest.java
+++ b/src/test/java/com/gdg/Todak/diary/service/DiaryServiceTest.java
@@ -1,0 +1,302 @@
+package com.gdg.Todak.diary.service;
+
+import com.gdg.Todak.diary.Emotion;
+import com.gdg.Todak.diary.dto.DiaryRequest;
+import com.gdg.Todak.diary.dto.DiarySummaryResponse;
+import com.gdg.Todak.diary.entity.Diary;
+import com.gdg.Todak.diary.exception.BadRequestException;
+import com.gdg.Todak.diary.exception.NotFoundException;
+import com.gdg.Todak.diary.exception.UnauthorizedException;
+import com.gdg.Todak.diary.repository.DiaryRepository;
+import com.gdg.Todak.friend.FriendStatus;
+import com.gdg.Todak.friend.entity.Friend;
+import com.gdg.Todak.friend.repository.FriendRepository;
+import com.gdg.Todak.member.domain.Member;
+import com.gdg.Todak.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@Transactional
+class DiaryServiceTest {
+
+    @Autowired
+    private DiaryService diaryService;
+
+    @Autowired
+    private DiaryRepository diaryRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private FriendRepository friendRepository;
+
+    private Member writer;
+    private Member nonWriter;
+
+    @BeforeEach
+    void setUp() {
+        writer = memberRepository.save(new Member("writerUser", "test1", "test1", "test1"));
+        nonWriter = memberRepository.save(new Member("nonWriterUser", "test2", "test2", "test2"));
+
+        friendRepository.save(Friend.builder().requester(writer).accepter(nonWriter).friendStatus(FriendStatus.ACCEPTED).build());
+    }
+
+    @Test
+    @DisplayName("일기 작성 성공")
+    void writeDiarySuccessfullyTest() {
+        // given
+        DiaryRequest diaryRequest = new DiaryRequest("오늘은 기분이 좋다.", Emotion.HAPPY);
+
+        // when
+        diaryService.writeDiary(writer.getUsername(), diaryRequest);
+
+        // then
+        Optional<Diary> diary = diaryRepository.findByMemberAndContent(writer, "오늘은 기분이 좋다.");
+        assertThat(diary).isPresent();
+        assertThat(diary.get().getContent()).isEqualTo("오늘은 기분이 좋다.");
+        assertThat(diary.get().getEmotion()).isEqualTo(Emotion.HAPPY);
+    }
+
+    @Test
+    @DisplayName("하루에 이미 작성된 일기 존재 시 작성 불가")
+    void cannotWriteDiaryIfAlreadyExistsTest() {
+        // given
+        DiaryRequest diaryRequest = new DiaryRequest("오늘은 기분이 좋다.", Emotion.HAPPY);
+        diaryService.writeDiary(writer.getUsername(), diaryRequest);
+
+        // when & then
+        assertThatThrownBy(() -> diaryService.writeDiary(writer.getUsername(), diaryRequest))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("오늘 이미 작성된 일기 또는 감정이 있습니다. 삭제 후 재작성하거나 작성된 일기를 수정해주세요.");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원에 대한 일기 작성 시 예외 발생")
+    void writeDiaryForNonExistingMemberTest() {
+        // given
+        DiaryRequest diaryRequest = new DiaryRequest("오늘은 기분이 좋다.", Emotion.HAPPY);
+
+        // when & then
+        assertThatThrownBy(() -> diaryService.writeDiary("nonExistentUser", diaryRequest))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("memberName에 해당하는 멤버가 없습니다.");
+    }
+
+    @Test
+    @DisplayName("자신의 일기 조회 성공")
+    void readOwnDiarySuccessfullyTest() {
+        // given
+        Diary diary = diaryRepository.save(Diary.builder()
+                .member(writer)
+                .content("오늘은 기분이 좋다.")
+                .emotion(Emotion.HAPPY)
+                .build());
+
+        // when
+        var diaryDetail = diaryService.readDiary(writer.getUsername(), diary.getId());
+
+        // then
+        assertThat(diaryDetail).isNotNull();
+        assertThat(diaryDetail.content()).isEqualTo("오늘은 기분이 좋다.");
+        assertThat(diaryDetail.emotion()).isEqualTo(Emotion.HAPPY);
+        assertThat(diaryDetail.isWriter()).isTrue();
+    }
+
+    @Test
+    @DisplayName("자신의 일기 요약 조회 성공")
+    void getOwnSummaryByYearAndMonthSuccessfullyTest() {
+        // given
+        Instant now = Instant.now();
+        int year = now.atZone(ZoneId.systemDefault()).getYear();
+        int month = now.atZone(ZoneId.systemDefault()).getMonthValue();
+
+        Diary diary1 = diaryRepository.save(Diary.builder()
+                .member(writer)
+                .content("자신의 3월 첫 번째 일기")
+                .emotion(Emotion.HAPPY)
+                .build());
+        ReflectionTestUtils.setField(diary1, "createdAt", Instant.now());
+
+
+        Diary diary2 = diaryRepository.save(Diary.builder()
+                .member(writer)
+                .content("자신의 3월 두 번째 일기")
+                .emotion(Emotion.SAD)
+                .build());
+        ReflectionTestUtils.setField(diary2, "createdAt", Instant.now());
+
+
+        // when
+        List<DiarySummaryResponse> summaries = diaryService.getOwnSummaryByYearAndMonth(writer.getUsername(), year, month);
+
+        // then
+        assertThat(summaries).hasSize(2);
+        assertThat(summaries.get(0).emotion()).isEqualTo(Emotion.HAPPY);
+        assertThat(summaries.get(1).emotion()).isEqualTo(Emotion.SAD);
+    }
+
+    @Test
+    @DisplayName("친구의 일기 요약 조회 성공")
+    void getFriendSummaryByYearAndMonthSuccessfullyTest() {
+        // given
+        Instant now = Instant.now();
+        int year = now.atZone(ZoneId.systemDefault()).getYear();
+        int month = now.atZone(ZoneId.systemDefault()).getMonthValue();
+
+        // 회원과 친구에 해당하는 일기 데이터 생성
+        Diary diary1 = diaryRepository.save(Diary.builder()
+                .member(nonWriter)
+                .content("친구의 3월 첫 번째 일기")
+                .emotion(Emotion.HAPPY)
+                .build());
+        ReflectionTestUtils.setField(diary1, "createdAt", Instant.now());
+
+
+        Diary diary2 = diaryRepository.save(Diary.builder()
+                .member(nonWriter)
+                .content("친구의 3월 두 번째 일기")
+                .emotion(Emotion.SAD)
+                .build());
+        ReflectionTestUtils.setField(diary2, "createdAt", Instant.now());
+
+        // when
+        List<DiarySummaryResponse> summaries = diaryService.getFriendSummaryByYearAndMonth(writer.getUsername(), nonWriter.getUsername(), year, month);
+
+        // then
+        assertThat(summaries).hasSize(2);
+        assertThat(summaries.get(0).emotion()).isEqualTo(Emotion.HAPPY);
+        assertThat(summaries.get(1).emotion()).isEqualTo(Emotion.SAD);
+    }
+
+    @Test
+    @DisplayName("타인의 일기 조회 성공 (친구만 조회 가능)")
+    void readFriendDiarySuccessfullyTest() {
+        // given
+        Diary diary = diaryRepository.save(Diary.builder()
+                .member(writer)
+                .content("오늘은 기분이 좋다.")
+                .emotion(Emotion.HAPPY)
+                .build());
+
+        // when
+        var diaryDetail = diaryService.readDiary(nonWriter.getUsername(), diary.getId());
+
+        // then
+        assertThat(diaryDetail).isNotNull();
+        assertThat(diaryDetail.content()).isEqualTo("오늘은 기분이 좋다.");
+        assertThat(diaryDetail.emotion()).isEqualTo(Emotion.HAPPY);
+        assertThat(diaryDetail.isWriter()).isFalse();
+    }
+
+    @Test
+    @DisplayName("자신의 일기가 아니면 조회 불가")
+    void cannotReadNonOwnDiaryTest() {
+        // given
+        Diary diary = diaryRepository.save(Diary.builder()
+                .member(writer)
+                .content("오늘은 기분이 좋다.")
+                .emotion(Emotion.HAPPY)
+                .build());
+
+        Member newMember = memberRepository.save(Member.builder()
+                .username("newMember")
+                .password("password")
+                .salt("salt")
+                .imageUrl("imageUrl")
+                .build());
+
+        // when & then
+        assertThatThrownBy(() -> diaryService.readDiary(newMember.getUsername(), diary.getId()))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasMessage("작성자 또는 작성자의 친구만 일기 조회가 가능합니다.");
+    }
+
+    @Test
+    @DisplayName("일기 수정 성공")
+    void updateDiarySuccessfullyTest() {
+        // given
+        Diary diary = diaryRepository.save(Diary.builder()
+                .member(writer)
+                .content("오늘은 기분이 좋다.")
+                .emotion(Emotion.HAPPY)
+                .build());
+
+        DiaryRequest updateRequest = new DiaryRequest("오늘은 기분이 매우 좋다.", Emotion.HAPPY);
+
+        // when
+        diaryService.updateDiary(writer.getUsername(), diary.getId(), updateRequest);
+
+        // then
+        Optional<Diary> updatedDiary = diaryRepository.findById(diary.getId());
+        assertThat(updatedDiary).isPresent();
+        assertThat(updatedDiary.get().getContent()).isEqualTo("오늘은 기분이 매우 좋다.");
+        assertThat(updatedDiary.get().getEmotion()).isEqualTo(Emotion.HAPPY);
+    }
+
+    @Test
+    @DisplayName("일기 수정 시 작성자가 아니면 예외 발생")
+    void cannotUpdateDiaryIfNotOwnerTest() {
+        // given
+        Diary diary = diaryRepository.save(Diary.builder()
+                .member(writer)
+                .content("오늘은 기분이 좋다.")
+                .emotion(Emotion.HAPPY)
+                .build());
+
+        DiaryRequest updateRequest = new DiaryRequest("오늘은 기분이 별로다.", Emotion.SAD);
+
+        // when & then
+        assertThatThrownBy(() -> diaryService.updateDiary(nonWriter.getUsername(), diary.getId(), updateRequest))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasMessage("일기 작성자가 아닙니다.");
+    }
+
+    @Test
+    @DisplayName("일기 삭제 성공")
+    void deleteDiarySuccessfullyTest() {
+        // given
+        Diary diary = diaryRepository.save(Diary.builder()
+                .member(writer)
+                .content("오늘은 기분이 좋다.")
+                .emotion(Emotion.HAPPY)
+                .build());
+
+        // when
+        diaryService.deleteDiary(writer.getUsername(), diary.getId());
+
+        // then
+        Optional<Diary> deletedDiary = diaryRepository.findById(diary.getId());
+        assertThat(deletedDiary).isEmpty();
+    }
+
+    @Test
+    @DisplayName("일기 삭제 시 작성자가 아니면 예외 발생")
+    void cannotDeleteDiaryIfNotOwnerTest() {
+        // given
+        Diary diary = diaryRepository.save(Diary.builder()
+                .member(writer)
+                .content("오늘은 기분이 좋다.")
+                .emotion(Emotion.HAPPY)
+                .build());
+
+        // when & then
+        assertThatThrownBy(() -> diaryService.deleteDiary(nonWriter.getUsername(), diary.getId()))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasMessage("일기 작성자가 아닙니다.");
+    }
+}

--- a/src/test/java/com/gdg/Todak/diary/service/DiaryServiceTest.java
+++ b/src/test/java/com/gdg/Todak/diary/service/DiaryServiceTest.java
@@ -2,6 +2,7 @@ package com.gdg.Todak.diary.service;
 
 import com.gdg.Todak.diary.Emotion;
 import com.gdg.Todak.diary.dto.DiaryRequest;
+import com.gdg.Todak.diary.dto.DiarySearchRequest;
 import com.gdg.Todak.diary.dto.DiarySummaryResponse;
 import com.gdg.Todak.diary.entity.Diary;
 import com.gdg.Todak.diary.exception.BadRequestException;
@@ -124,6 +125,7 @@ class DiaryServiceTest {
         Instant now = Instant.now();
         int year = now.atZone(ZoneId.systemDefault()).getYear();
         int month = now.atZone(ZoneId.systemDefault()).getMonthValue();
+        DiarySearchRequest diarySearchRequest = new DiarySearchRequest(year, month);
 
         Diary diary1 = diaryRepository.save(Diary.builder()
                 .member(writer)
@@ -142,7 +144,7 @@ class DiaryServiceTest {
 
 
         // when
-        List<DiarySummaryResponse> summaries = diaryService.getMySummaryByYearAndMonth(writer.getUsername(), year, month);
+        List<DiarySummaryResponse> summaries = diaryService.getMySummaryByYearAndMonth(writer.getUsername(), diarySearchRequest);
 
         // then
         assertThat(summaries).hasSize(2);
@@ -157,6 +159,7 @@ class DiaryServiceTest {
         Instant now = Instant.now();
         int year = now.atZone(ZoneId.systemDefault()).getYear();
         int month = now.atZone(ZoneId.systemDefault()).getMonthValue();
+        DiarySearchRequest diarySearchRequest = new DiarySearchRequest(year, month);
 
         // 회원과 친구에 해당하는 일기 데이터 생성
         Diary diary1 = diaryRepository.save(Diary.builder()
@@ -175,7 +178,7 @@ class DiaryServiceTest {
         ReflectionTestUtils.setField(diary2, "createdAt", Instant.now());
 
         // when
-        List<DiarySummaryResponse> summaries = diaryService.getFriendSummaryByYearAndMonth(writer.getUsername(), nonWriter.getUsername(), year, month);
+        List<DiarySummaryResponse> summaries = diaryService.getFriendSummaryByYearAndMonth(writer.getUsername(), nonWriter.getUsername(), diarySearchRequest);
 
         // then
         assertThat(summaries).hasSize(2);

--- a/src/test/java/com/gdg/Todak/friend/controller/FriendControllerTest.java
+++ b/src/test/java/com/gdg/Todak/friend/controller/FriendControllerTest.java
@@ -20,8 +20,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
 
 import java.util.Arrays;
 import java.util.List;
@@ -44,8 +42,6 @@ class FriendControllerTest {
     private MockMvc mockMvc;
     @Autowired
     private ObjectMapper objectMapper;
-    @Autowired
-    private WebApplicationContext context;
     @MockitoBean
     private FriendService friendService;
     @MockitoBean
@@ -62,10 +58,6 @@ class FriendControllerTest {
 
         when(loginMemberArgumentResolver.supportsParameter(any())).thenReturn(true);
         when(loginMemberArgumentResolver.resolveArgument(any(), any(), any(), any())).thenReturn(authenticateUser);
-
-        mockMvc = MockMvcBuilders
-                .webAppContextSetup(context)
-                .build();
     }
 
     @Test
@@ -88,9 +80,11 @@ class FriendControllerTest {
     @DisplayName("친구 목록 조회 테스트")
     void getAllFriendsTest() throws Exception {
         // given
+        String friend1Name = "friend1";
+        String friend2Name = "friend2";
         List<FriendResponse> responses = Arrays.asList(
-                new FriendResponse(1L, "friend1"),
-                new FriendResponse(2L, "friend2")
+                new FriendResponse(1L, friend1Name),
+                new FriendResponse(2L, friend2Name)
         );
         when(friendService.getAllFriend(anyString())).thenReturn(responses);
 
@@ -98,17 +92,19 @@ class FriendControllerTest {
         mockMvc.perform(get("/api/v1/friend")
                         .header("Authorization", "Bearer " + token))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data[0].friendName").value("friend1"))
-                .andExpect(jsonPath("$.data[1].friendName").value("friend2"));
+                .andExpect(jsonPath("$.data[0].friendName").value(friend1Name))
+                .andExpect(jsonPath("$.data[1].friendName").value(friend2Name));
     }
 
     @Test
     @DisplayName("대기중인 친구 요청 조회 테스트")
     void getAllPendingFriendRequestTest() throws Exception {
         // given
+        String requester1Name = "requester1";
+        String requester2Name = "requester2";
         List<FriendRequestResponse> responses = Arrays.asList(
-                new FriendRequestResponse(1L, "requester1", "profile1"),
-                new FriendRequestResponse(2L, "requester2", "profile2")
+                new FriendRequestResponse(1L, requester1Name, "profile1"),
+                new FriendRequestResponse(2L, requester2Name, "profile2")
         );
         when(friendService.getAllFriendRequests(anyString())).thenReturn(responses);
 
@@ -116,17 +112,19 @@ class FriendControllerTest {
         mockMvc.perform(get("/api/v1/friend/pending")
                         .header("Authorization", "Bearer " + token))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data[0].requesterName").value("requester1"))
-                .andExpect(jsonPath("$.data[1].requesterName").value("requester2"));
+                .andExpect(jsonPath("$.data[0].requesterName").value(requester1Name))
+                .andExpect(jsonPath("$.data[1].requesterName").value(requester2Name));
     }
 
     @Test
     @DisplayName("거절한 친구 요청 조회 테스트")
     void getAllDeclinedFriendRequestTest() throws Exception {
         // given
+        String decliner1Name = "decliner1";
+        String decliner2Name = "decliner2";
         List<FriendRequestResponse> responses = Arrays.asList(
-                new FriendRequestResponse(1L, "decliner1", "profile1"),
-                new FriendRequestResponse(2L, "decliner2", "profile2")
+                new FriendRequestResponse(1L, decliner1Name, "profile1"),
+                new FriendRequestResponse(2L, decliner2Name, "profile2")
         );
         when(friendService.getAllDeclinedFriends(anyString())).thenReturn(responses);
 
@@ -134,8 +132,8 @@ class FriendControllerTest {
         mockMvc.perform(get("/api/v1/friend/declined")
                         .header("Authorization", "Bearer " + token))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data[0].requesterName").value("decliner1"))
-                .andExpect(jsonPath("$.data[1].requesterName").value("decliner2"));
+                .andExpect(jsonPath("$.data[0].requesterName").value(decliner1Name))
+                .andExpect(jsonPath("$.data[1].requesterName").value(decliner2Name));
     }
 
     @Test
@@ -184,9 +182,11 @@ class FriendControllerTest {
     @DisplayName("친구요청수 및 친구수 확인 테스트")
     void getMyFriendCountTest() throws Exception {
         // given
+        Long pendingCount = 5L;
+        Long acceptedCount = 10L;
         List<FriendCountResponse> responses = Arrays.asList(
-                new FriendCountResponse(FriendStatus.PENDING, 5L),
-                new FriendCountResponse(FriendStatus.ACCEPTED, 10L)
+                new FriendCountResponse(FriendStatus.PENDING, pendingCount),
+                new FriendCountResponse(FriendStatus.ACCEPTED, acceptedCount)
         );
         when(friendService.getMyFriendCountByStatus(anyString())).thenReturn(responses);
 
@@ -195,8 +195,8 @@ class FriendControllerTest {
                         .header("Authorization", "Bearer " + token))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data[0].friendStatus").value("PENDING"))
-                .andExpect(jsonPath("$.data[0].count").value(5))
+                .andExpect(jsonPath("$.data[0].count").value(pendingCount))
                 .andExpect(jsonPath("$.data[1].friendStatus").value("ACCEPTED"))
-                .andExpect(jsonPath("$.data[1].count").value(10));
+                .andExpect(jsonPath("$.data[1].count").value(acceptedCount));
     }
 }

--- a/src/test/java/com/gdg/Todak/friend/controller/FriendControllerTest.java
+++ b/src/test/java/com/gdg/Todak/friend/controller/FriendControllerTest.java
@@ -182,13 +182,13 @@ class FriendControllerTest {
 
     @Test
     @DisplayName("친구요청수 및 친구수 확인 테스트")
-    void getOwnFriendCountTest() throws Exception {
+    void getMyFriendCountTest() throws Exception {
         // given
         List<FriendCountResponse> responses = Arrays.asList(
                 new FriendCountResponse(FriendStatus.PENDING, 5L),
                 new FriendCountResponse(FriendStatus.ACCEPTED, 10L)
         );
-        when(friendService.getOwnFriendCountByStatus(anyString())).thenReturn(responses);
+        when(friendService.getMyFriendCountByStatus(anyString())).thenReturn(responses);
 
         // when & then
         mockMvc.perform(get("/api/v1/friend/count")

--- a/src/test/java/com/gdg/Todak/friend/controller/FriendControllerTest.java
+++ b/src/test/java/com/gdg/Todak/friend/controller/FriendControllerTest.java
@@ -1,0 +1,189 @@
+package com.gdg.Todak.friend.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gdg.Todak.friend.FriendStatus;
+import com.gdg.Todak.friend.dto.FriendCountResponse;
+import com.gdg.Todak.friend.dto.FriendNameRequest;
+import com.gdg.Todak.friend.dto.FriendRequestResponse;
+import com.gdg.Todak.friend.dto.FriendResponse;
+import com.gdg.Todak.friend.service.FriendService;
+import com.gdg.Todak.member.Interceptor.LoginCheckInterceptor;
+import com.gdg.Todak.member.controller.TestWebConfig;
+import com.gdg.Todak.member.domain.AuthenticateUser;
+import com.gdg.Todak.member.domain.Role;
+import com.gdg.Todak.member.resolver.LoginMemberArgumentResolver;
+import com.gdg.Todak.member.service.MemberService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(FriendController.class)
+@Import(TestWebConfig.class)
+class FriendControllerTest {
+
+    private final String token = "testToken";
+    @MockitoBean
+    MemberService memberService;
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private WebApplicationContext context;
+    @MockitoBean
+    private FriendService friendService;
+    @MockitoBean
+    private LoginCheckInterceptor loginCheckInterceptor;
+    @MockitoBean
+    private LoginMemberArgumentResolver loginMemberArgumentResolver;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        when(loginCheckInterceptor.preHandle(any(), any(), any())).thenReturn(true);
+
+        String username = "testUser";
+        AuthenticateUser authenticateUser = new AuthenticateUser(username, Set.of(Role.USER));
+
+        when(loginMemberArgumentResolver.supportsParameter(any())).thenReturn(true);
+        when(loginMemberArgumentResolver.resolveArgument(any(), any(), any(), any())).thenReturn(authenticateUser);
+
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .build();
+    }
+
+    @Test
+    @DisplayName("친구 요청 보내기 테스트")
+    void sendFriendRequestTest() throws Exception {
+        FriendNameRequest request = new FriendNameRequest("friendName");
+        doNothing().when(friendService).makeFriendRequest(anyString(), any(FriendNameRequest.class));
+
+        mockMvc.perform(post("/api/v1/friend")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.message").value("친구 요청이 생성되었습니다."));
+    }
+
+    @Test
+    @DisplayName("친구 목록 조회 테스트")
+    void getAllFriendsTest() throws Exception {
+        List<FriendResponse> responses = Arrays.asList(
+                new FriendResponse(1L, "friend1"),
+                new FriendResponse(2L, "friend2")
+        );
+        when(friendService.getAllFriend(anyString())).thenReturn(responses);
+
+        mockMvc.perform(get("/api/v1/friend")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].friendName").value("friend1"))
+                .andExpect(jsonPath("$.data[1].friendName").value("friend2"));
+    }
+
+    @Test
+    @DisplayName("대기중인 친구 요청 조회 테스트")
+    void getAllPendingFriendRequestTest() throws Exception {
+        List<FriendRequestResponse> responses = Arrays.asList(
+                new FriendRequestResponse(1L, "requester1", "profile1"),
+                new FriendRequestResponse(2L, "requester2", "profile2")
+        );
+        when(friendService.getAllFriendRequests(anyString())).thenReturn(responses);
+
+        mockMvc.perform(get("/api/v1/friend/pending")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].requesterName").value("requester1"))
+                .andExpect(jsonPath("$.data[1].requesterName").value("requester2"));
+    }
+
+    @Test
+    @DisplayName("거절한 친구 요청 조회 테스트")
+    void getAllDeclinedFriendRequestTest() throws Exception {
+        List<FriendRequestResponse> responses = Arrays.asList(
+                new FriendRequestResponse(1L, "decliner1", "profile1"),
+                new FriendRequestResponse(2L, "decliner2", "profile2")
+        );
+        when(friendService.getAllDeclinedFriends(anyString())).thenReturn(responses);
+
+        mockMvc.perform(get("/api/v1/friend/declined")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].requesterName").value("decliner1"))
+                .andExpect(jsonPath("$.data[1].requesterName").value("decliner2"));
+    }
+
+    @Test
+    @DisplayName("친구 요청 수락 테스트")
+    void acceptFriendRequestTest() throws Exception {
+        Long friendRequestId = 1L;
+        doNothing().when(friendService).acceptFriendRequest(anyString(), anyLong());
+
+        mockMvc.perform(put("/api/v1/friend/accept/" + friendRequestId)
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("친구 요청이 수락되었습니다."));
+    }
+
+    @Test
+    @DisplayName("친구 요청 거절 테스트")
+    void declineFriendRequestTest() throws Exception {
+        Long friendRequestId = 1L;
+        doNothing().when(friendService).declineFriendRequest(anyString(), anyLong());
+
+        mockMvc.perform(put("/api/v1/friend/decline/" + friendRequestId)
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("친구 요청을 거절하였습니다."));
+    }
+
+    @Test
+    @DisplayName("친구 삭제 테스트")
+    void deleteFriendTest() throws Exception {
+        Long friendRequestId = 1L;
+        doNothing().when(friendService).deleteFriend(anyString(), anyLong());
+
+        mockMvc.perform(delete("/api/v1/friend/" + friendRequestId)
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("친구/친구요청을 삭제하였습니다."));
+    }
+
+    @Test
+    @DisplayName("친구요청수 및 친구수 확인 테스트")
+    void getOwnFriendCountTest() throws Exception {
+        List<FriendCountResponse> responses = Arrays.asList(
+                new FriendCountResponse(FriendStatus.PENDING, 5L),
+                new FriendCountResponse(FriendStatus.ACCEPTED, 10L)
+        );
+        when(friendService.getOwnFriendCountByStatus(anyString())).thenReturn(responses);
+
+        mockMvc.perform(get("/api/v1/friend/count")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].friendStatus").value("PENDING"))
+                .andExpect(jsonPath("$.data[0].count").value(5))
+                .andExpect(jsonPath("$.data[1].friendStatus").value("ACCEPTED"))
+                .andExpect(jsonPath("$.data[1].count").value(10));
+    }
+}

--- a/src/test/java/com/gdg/Todak/friend/controller/FriendControllerTest.java
+++ b/src/test/java/com/gdg/Todak/friend/controller/FriendControllerTest.java
@@ -8,7 +8,6 @@ import com.gdg.Todak.friend.dto.FriendRequestResponse;
 import com.gdg.Todak.friend.dto.FriendResponse;
 import com.gdg.Todak.friend.service.FriendService;
 import com.gdg.Todak.member.Interceptor.LoginCheckInterceptor;
-import com.gdg.Todak.member.controller.TestWebConfig;
 import com.gdg.Todak.member.domain.AuthenticateUser;
 import com.gdg.Todak.member.domain.Role;
 import com.gdg.Todak.member.resolver.LoginMemberArgumentResolver;
@@ -18,7 +17,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -37,7 +35,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(FriendController.class)
-@Import(TestWebConfig.class)
 class FriendControllerTest {
 
     private final String token = "testToken";
@@ -74,9 +71,11 @@ class FriendControllerTest {
     @Test
     @DisplayName("친구 요청 보내기 테스트")
     void sendFriendRequestTest() throws Exception {
+        // given
         FriendNameRequest request = new FriendNameRequest("friendName");
         doNothing().when(friendService).makeFriendRequest(anyString(), any(FriendNameRequest.class));
 
+        // when & then
         mockMvc.perform(post("/api/v1/friend")
                         .header("Authorization", "Bearer " + token)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -88,12 +87,14 @@ class FriendControllerTest {
     @Test
     @DisplayName("친구 목록 조회 테스트")
     void getAllFriendsTest() throws Exception {
+        // given
         List<FriendResponse> responses = Arrays.asList(
                 new FriendResponse(1L, "friend1"),
                 new FriendResponse(2L, "friend2")
         );
         when(friendService.getAllFriend(anyString())).thenReturn(responses);
 
+        // when & then
         mockMvc.perform(get("/api/v1/friend")
                         .header("Authorization", "Bearer " + token))
                 .andExpect(status().isOk())
@@ -104,12 +105,14 @@ class FriendControllerTest {
     @Test
     @DisplayName("대기중인 친구 요청 조회 테스트")
     void getAllPendingFriendRequestTest() throws Exception {
+        // given
         List<FriendRequestResponse> responses = Arrays.asList(
                 new FriendRequestResponse(1L, "requester1", "profile1"),
                 new FriendRequestResponse(2L, "requester2", "profile2")
         );
         when(friendService.getAllFriendRequests(anyString())).thenReturn(responses);
 
+        // when & then
         mockMvc.perform(get("/api/v1/friend/pending")
                         .header("Authorization", "Bearer " + token))
                 .andExpect(status().isOk())
@@ -120,12 +123,14 @@ class FriendControllerTest {
     @Test
     @DisplayName("거절한 친구 요청 조회 테스트")
     void getAllDeclinedFriendRequestTest() throws Exception {
+        // given
         List<FriendRequestResponse> responses = Arrays.asList(
                 new FriendRequestResponse(1L, "decliner1", "profile1"),
                 new FriendRequestResponse(2L, "decliner2", "profile2")
         );
         when(friendService.getAllDeclinedFriends(anyString())).thenReturn(responses);
 
+        // when & then
         mockMvc.perform(get("/api/v1/friend/declined")
                         .header("Authorization", "Bearer " + token))
                 .andExpect(status().isOk())
@@ -136,9 +141,11 @@ class FriendControllerTest {
     @Test
     @DisplayName("친구 요청 수락 테스트")
     void acceptFriendRequestTest() throws Exception {
+        // given
         Long friendRequestId = 1L;
         doNothing().when(friendService).acceptFriendRequest(anyString(), anyLong());
 
+        // when & then
         mockMvc.perform(put("/api/v1/friend/accept/" + friendRequestId)
                         .header("Authorization", "Bearer " + token))
                 .andExpect(status().isOk())
@@ -148,9 +155,11 @@ class FriendControllerTest {
     @Test
     @DisplayName("친구 요청 거절 테스트")
     void declineFriendRequestTest() throws Exception {
+        // given
         Long friendRequestId = 1L;
         doNothing().when(friendService).declineFriendRequest(anyString(), anyLong());
 
+        // when & then
         mockMvc.perform(put("/api/v1/friend/decline/" + friendRequestId)
                         .header("Authorization", "Bearer " + token))
                 .andExpect(status().isOk())
@@ -160,9 +169,11 @@ class FriendControllerTest {
     @Test
     @DisplayName("친구 삭제 테스트")
     void deleteFriendTest() throws Exception {
+        // given
         Long friendRequestId = 1L;
         doNothing().when(friendService).deleteFriend(anyString(), anyLong());
 
+        // when & then
         mockMvc.perform(delete("/api/v1/friend/" + friendRequestId)
                         .header("Authorization", "Bearer " + token))
                 .andExpect(status().isOk())
@@ -172,12 +183,14 @@ class FriendControllerTest {
     @Test
     @DisplayName("친구요청수 및 친구수 확인 테스트")
     void getOwnFriendCountTest() throws Exception {
+        // given
         List<FriendCountResponse> responses = Arrays.asList(
                 new FriendCountResponse(FriendStatus.PENDING, 5L),
                 new FriendCountResponse(FriendStatus.ACCEPTED, 10L)
         );
         when(friendService.getOwnFriendCountByStatus(anyString())).thenReturn(responses);
 
+        // when & then
         mockMvc.perform(get("/api/v1/friend/count")
                         .header("Authorization", "Bearer " + token))
                 .andExpect(status().isOk())

--- a/src/test/java/com/gdg/Todak/friend/entity/FriendTest.java
+++ b/src/test/java/com/gdg/Todak/friend/entity/FriendTest.java
@@ -1,0 +1,97 @@
+package com.gdg.Todak.friend.entity;
+
+import com.gdg.Todak.friend.FriendStatus;
+import com.gdg.Todak.friend.exception.BadRequestException;
+import com.gdg.Todak.member.domain.Member;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class FriendTest {
+
+    private Friend friend;
+    private Member requester;
+    private Member accepter;
+
+    @BeforeEach
+    void setUp() {
+        requester = new Member("user1", "test1", "test1", "test1");
+        accepter = new Member("user2", "test2", "test2", "test2");
+
+        friend = Friend.builder().requester(requester).accepter(accepter).friendStatus(FriendStatus.PENDING).build();
+    }
+
+    @DisplayName("Friend 객체 생성 테스트")
+    @Test
+    void constructorTest() {
+        assertThat(friend).isNotNull();
+        assertThat(friend.getRequester()).isEqualTo(requester);
+        assertThat(friend.getAccepter()).isEqualTo(accepter);
+        assertThat(friend.getFriendStatus()).isEqualTo(FriendStatus.PENDING);
+    }
+
+    @DisplayName("친구 요청을 수락하면 상태가 ACCEPTED로 변경되어야 한다")
+    @Test
+    void acceptFriendRequestTest() {
+        // when
+        friend.acceptFriendRequest();
+
+        // then
+        assertThat(friend.getFriendStatus()).isEqualTo(FriendStatus.ACCEPTED);
+    }
+
+    @DisplayName("이미 ACCEPTED 상태인 친구 요청을 다시 수락하면 예외 발생")
+    @Test
+    void acceptFriendRequest_alreadyAcceptedTest() {
+        // given
+        friend.acceptFriendRequest();
+
+        // when & then
+        assertThatThrownBy(() -> friend.acceptFriendRequest())
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("대기중인 친구 요청이 아닙니다.");
+    }
+
+    @DisplayName("친구 요청을 거절하면 상태가 DECLINED로 변경되어야 한다")
+    @Test
+    void declinedFriendRequestTest() {
+        // when
+        friend.declinedFriendRequest();
+
+        // then
+        assertThat(friend.getFriendStatus()).isEqualTo(FriendStatus.DECLINED);
+    }
+
+    @DisplayName("이미 DECLINED 상태인 친구 요청을 다시 거절하면 예외 발생")
+    @Test
+    void declinedFriendRequest_alreadyDeclinedTest() {
+        // given
+        friend.declinedFriendRequest();
+
+        // when & then
+        assertThatThrownBy(() -> friend.declinedFriendRequest())
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("대기중인 친구 요청이 아닙니다.");
+    }
+
+    @DisplayName("요청자가 아닌 사용자가 checkMemberIsNotRequester 호출 시 true 반환")
+    @Test
+    void checkMemberIsNotRequesterTest() {
+        Member otherUser = new Member("user3", "test3", "test3", "test3");
+
+        assertThat(friend.checkMemberIsNotRequester(otherUser)).isTrue();
+        assertThat(friend.checkMemberIsNotRequester(requester)).isFalse();
+    }
+
+    @DisplayName("수락자가 아닌 사용자가 checkMemberIsNotAccepter 호출 시 true 반환")
+    @Test
+    void checkMemberIsNotAccepterTest() {
+        Member otherUser = new Member("user3", "test3", "test3", "test3");
+
+        assertThat(friend.checkMemberIsNotAccepter(otherUser)).isTrue();
+        assertThat(friend.checkMemberIsNotAccepter(accepter)).isFalse();
+    }
+}

--- a/src/test/java/com/gdg/Todak/friend/repository/FriendRepositoryTest.java
+++ b/src/test/java/com/gdg/Todak/friend/repository/FriendRepositoryTest.java
@@ -1,0 +1,155 @@
+package com.gdg.Todak.friend.repository;
+
+import com.gdg.Todak.friend.FriendStatus;
+import com.gdg.Todak.friend.entity.Friend;
+import com.gdg.Todak.member.domain.Member;
+import com.gdg.Todak.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class FriendRepositoryTest {
+
+    @Autowired
+    FriendRepository friendRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @DisplayName("friend 객체 정상 저장 테스트")
+    @Test
+    void friendSaveTest() {
+        // given
+        Member requester = new Member("user1", "test1", "test1", "test1");
+        Member accepter = new Member("user2", "test2", "test2", "test2");
+
+        memberRepository.save(requester);
+        memberRepository.save(accepter);
+
+        Friend newFriend = Friend.builder()
+                .requester(requester)
+                .accepter(accepter)
+                .friendStatus(FriendStatus.PENDING)
+                .build();
+
+        // when
+        Friend savedFriend = friendRepository.save(newFriend);
+
+        // then
+        assertThat(savedFriend.getId()).isNotNull();
+        assertThat(savedFriend.getRequester().getId()).isNotNull();
+        assertThat(savedFriend.getAccepter().getId()).isNotNull();
+        assertThat(savedFriend.getFriendStatus()).isEqualTo(FriendStatus.PENDING);
+    }
+
+    @DisplayName("existsByRequesterAndAccepter() 테스트 - 친구 관계 존재 여부 확인")
+    @Test
+    void existsByRequesterAndAccepterTest() {
+        // given
+        Member requester = memberRepository.save(new Member("user1", "test1", "test1", "test1"));
+        Member accepter = memberRepository.save(new Member("user2", "test2", "test2", "test2"));
+
+        friendRepository.save(Friend.builder()
+                .requester(requester)
+                .accepter(accepter)
+                .friendStatus(FriendStatus.ACCEPTED)
+                .build());
+
+        // when
+        boolean exists = friendRepository.existsByRequesterAndAccepter(requester, accepter);
+
+        // then
+        assertThat(exists).isTrue();
+    }
+
+    @DisplayName("findAllByAccepterUsernameAndFriendStatusOrRequesterUsernameAndFriendStatus() 테스트 - 친구 찾기 정상 작동 확인")
+    @Test
+    void findAllByAccepterOrRequesterAndStatusTest() {
+        // given
+        Member requester = memberRepository.save(new Member("user1", "test1", "test1", "test1"));
+        Member accepter = memberRepository.save(new Member("user2", "test2", "test2", "test2"));
+        Member other = memberRepository.save(new Member("user3", "test3", "test3", "test3"));
+
+        friendRepository.save(Friend.builder()
+                .requester(requester)
+                .accepter(accepter)
+                .friendStatus(FriendStatus.ACCEPTED)
+                .build());
+
+        friendRepository.save(Friend.builder()
+                .requester(accepter)
+                .accepter(other)
+                .friendStatus(FriendStatus.ACCEPTED)
+                .build());
+
+        // when
+        List<Friend> friends = friendRepository.findAllByAccepterUsernameAndFriendStatusOrRequesterUsernameAndFriendStatus(
+                "user2", FriendStatus.ACCEPTED, "user2", FriendStatus.ACCEPTED
+        );
+
+        // then
+        assertThat(friends).hasSize(2);
+    }
+
+    @DisplayName("countByRequesterAndStatusIn() 테스트 - requester 기준으로 특정 상태의 친구요청 개수 확인")
+    @Test
+    void countByRequesterAndStatusInTest() {
+        // given
+        Member requester = memberRepository.save(new Member("user1", "test1", "test1", "test1"));
+        Member accepter1 = memberRepository.save(new Member("user2", "test2", "test2", "test2"));
+        Member accepter2 = memberRepository.save(new Member("user3", "test3", "test3", "test3"));
+
+        friendRepository.save(Friend.builder()
+                .requester(requester)
+                .accepter(accepter1)
+                .friendStatus(FriendStatus.PENDING)
+                .build());
+
+        friendRepository.save(Friend.builder()
+                .requester(requester)
+                .accepter(accepter2)
+                .friendStatus(FriendStatus.ACCEPTED)
+                .build());
+
+        // when
+        long count = friendRepository.countByRequesterAndStatusIn(requester, List.of(FriendStatus.PENDING, FriendStatus.ACCEPTED));
+
+        // then
+        assertThat(count).isEqualTo(2);
+    }
+
+    @DisplayName("countByAccepterAndStatusIn() 테스트 - accepter 기준으로 특정 상태의 친구요청 개수 확인")
+    @Test
+    void countByAccepterAndStatusInTest() {
+        // given
+        Member requester1 = memberRepository.save(new Member("user1", "test1", "test1", "test1"));
+        Member requester2 = memberRepository.save(new Member("user2", "test2", "test2", "test2"));
+        Member accepter = memberRepository.save(new Member("user3", "test3", "test3", "test3"));
+
+        friendRepository.save(Friend.builder()
+                .requester(requester1)
+                .accepter(accepter)
+                .friendStatus(FriendStatus.PENDING)
+                .build());
+
+        friendRepository.save(Friend.builder()
+                .requester(requester2)
+                .accepter(accepter)
+                .friendStatus(FriendStatus.ACCEPTED)
+                .build());
+
+        // when
+        long count = friendRepository.countByAccepterAndStatusIn(accepter, List.of(FriendStatus.PENDING, FriendStatus.ACCEPTED));
+
+        // then
+        assertThat(count).isEqualTo(2);
+    }
+}

--- a/src/test/java/com/gdg/Todak/friend/service/FriendServiceTest.java
+++ b/src/test/java/com/gdg/Todak/friend/service/FriendServiceTest.java
@@ -1,0 +1,127 @@
+package com.gdg.Todak.friend.service;
+
+import com.gdg.Todak.friend.FriendStatus;
+import com.gdg.Todak.friend.dto.FriendNameRequest;
+import com.gdg.Todak.friend.entity.Friend;
+import com.gdg.Todak.friend.exception.BadRequestException;
+import com.gdg.Todak.friend.repository.FriendRepository;
+import com.gdg.Todak.member.domain.Member;
+import com.gdg.Todak.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@Transactional
+class FriendServiceTest {
+
+    @Autowired
+    private FriendService friendService;
+
+    @Autowired
+    private FriendRepository friendRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Member requester;
+    private Member accepter;
+
+    @BeforeEach
+    void setUp() {
+        requester = memberRepository.save(new Member("requesterUser", "test1", "test1", "test1"));
+        accepter = memberRepository.save(new Member("accepterUser", "test2", "test2", "test2"));
+    }
+
+    @Test
+    @DisplayName("친구 요청 성공")
+    void makeFriendRequestSuccessfullyTest() {
+        //given
+        FriendNameRequest request = new FriendNameRequest(accepter.getUsername());
+
+        //when
+        friendService.makeFriendRequest(requester.getUsername(), request);
+
+        //then
+        Optional<Friend> friendRequest = friendRepository.findByRequesterAndAccepter(requester, accepter);
+        assertThat(friendRequest).isPresent();
+        assertThat(friendRequest.get().getFriendStatus()).isEqualTo(FriendStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("본인에게 친구 요청 불가")
+    void notAllowSelfFriendRequestTest() {
+        //given
+        FriendNameRequest request = new FriendNameRequest(requester.getUsername());
+
+        //when & then
+        assertThatThrownBy(() -> friendService.makeFriendRequest(requester.getUsername(), request))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("본인에게는 친구 요청을 할 수 없습니다");
+    }
+
+    @Test
+    @DisplayName("중복 친구 요청 불가")
+    void notAllowDuplicateFriendRequestTest() {
+        //given
+        FriendNameRequest request = new FriendNameRequest(accepter.getUsername());
+
+        //when
+        friendService.makeFriendRequest(requester.getUsername(), request);
+
+        //then
+        assertThatThrownBy(() -> friendService.makeFriendRequest(requester.getUsername(), request))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("이미 친구이거나, 대기 또는 거절된 친구요청이 존재합니다.");
+    }
+
+    @Test
+    @DisplayName("친구 요청 수락")
+    void acceptFriendRequestTest() {
+        //given
+        Friend friend = friendRepository.save(Friend.builder().requester(requester).accepter(accepter).friendStatus(FriendStatus.PENDING).build());
+
+        //when
+        friendService.acceptFriendRequest(accepter.getUsername(), friend.getId());
+
+        //then
+        Friend updatedFriend = friendRepository.findById(friend.getId()).orElseThrow();
+        assertThat(updatedFriend.getFriendStatus()).isEqualTo(FriendStatus.ACCEPTED);
+    }
+
+    @Test
+    @DisplayName("친구 요청 거절")
+    void declineFriendRequestTest() {
+        //given
+        Friend friend = friendRepository.save(Friend.builder().requester(requester).accepter(accepter).friendStatus(FriendStatus.PENDING).build());
+
+        //when
+        friendService.declineFriendRequest(accepter.getUsername(), friend.getId());
+
+        //then
+        Friend updatedFriend = friendRepository.findById(friend.getId()).orElseThrow();
+        assertThat(updatedFriend.getFriendStatus()).isEqualTo(FriendStatus.DECLINED);
+    }
+
+    @Test
+    @DisplayName("친구 삭제")
+    void deleteFriendTest() {
+        //given
+        Friend friend = friendRepository.save(Friend.builder().requester(requester).accepter(accepter).friendStatus(FriendStatus.ACCEPTED).build());
+
+        //when
+        friendService.deleteFriend(requester.getUsername(), friend.getId());
+
+        //then
+        Optional<Friend> deletedFriend = friendRepository.findById(friend.getId());
+        assertThat(deletedFriend).isEmpty();
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #9 

## 📝 작업 내용
- 친구 로직 추가
- 친구 요청 관계성 처리
- 일기 로직 추가
- 일기로직 친구와 연동
- 테스트코드

## 💬 리뷰 요구사항(선택)
<img width="699" alt="image" src="https://github.com/user-attachments/assets/313c29fe-49dc-4004-bc33-ffddce40c1f0" />

친구 로직의 핵심은 친구요청을 대기, 수락, 거절 3가지 상태로 지속하여 가지고 있는 부분입니다.
일기 조회부분의 경우 프론트 @gogumalatte 과 합의하여 년/날짜별 조회로 결정하였습니다.
궁금하거나 수정사항이 있으면 말씀해주세요!

## ⏰ 현재 버그
이상 없습니다.

## ✏ Git Close
close #9 