### PR TITLE
Feat: 서버 이미지 처리공간 할당 및 이미지 처리 로직 추가

### DIFF
--- a/.github/workflows/docker-push-deploy.yml
+++ b/.github/workflows/docker-push-deploy.yml
@@ -34,6 +34,7 @@ jobs:
           MYSQL_USER: ${{ secrets.MYSQL_USER }}
           MYSQL_PASSWORD: ${{ secrets.MYSQL_PASSWORD }}
           MYSQL_DATABASE: ${{ secrets.MYSQL_DATABASE }}
+          MOUNT_PATH: ${{ secrets.MOUNT_PATH }}
 
       - name: 🐳 Set up Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/k8s/deployment.yaml.template
+++ b/k8s/deployment.yaml.template
@@ -44,6 +44,13 @@ spec:
             initialDelaySeconds: 40
             periodSeconds: 20
             failureThreshold: 3
+          volumeMounts:
+            - name: nfs-volume
+              mountPath: /usr/storage
+      volumes:
+        - name: nfs-volume
+          persistentVolumeClaim:
+            claimName: nfs-pvc
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/src/main/java/com/gdg/Todak/common/config/WebConfig.java
+++ b/src/main/java/com/gdg/Todak/common/config/WebConfig.java
@@ -3,6 +3,7 @@ package com.gdg.Todak.common.config;
 import com.gdg.Todak.member.Interceptor.LoginCheckInterceptor;
 import com.gdg.Todak.member.resolver.LoginMemberArgumentResolver;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
@@ -10,6 +11,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.List;
@@ -17,6 +19,11 @@ import java.util.List;
 @RequiredArgsConstructor
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${file.path}")
+    String uploadPath;
+    @Value("${image.url}")
+    String imageUrl;
 
     private final LoginCheckInterceptor loginCheckInterceptor;
     private final LoginMemberArgumentResolver loginMemberArgumentResolver;
@@ -27,7 +34,8 @@ public class WebConfig implements WebMvcConfigurer {
             "/api/v1/users/login",
             "/api/v1/users/logout",
             "/swagger-ui/**",
-            "/v3/api-docs/**"
+            "/v3/api-docs/**",
+            "/backend/**"
     );
 
     @Override
@@ -55,5 +63,11 @@ public class WebConfig implements WebMvcConfigurer {
         config.setMaxAge(3600L);
         source.registerCorsConfiguration("/**", config);
         return new CorsFilter(source);
+    }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler(imageUrl + "**")
+                .addResourceLocations("file://" + uploadPath);
     }
 }

--- a/src/main/java/com/gdg/Todak/diary/controller/DiaryController.java
+++ b/src/main/java/com/gdg/Todak/diary/controller/DiaryController.java
@@ -1,10 +1,7 @@
 package com.gdg.Todak.diary.controller;
 
 import com.gdg.Todak.common.domain.ApiResponse;
-import com.gdg.Todak.diary.dto.DiaryDetailResponse;
-import com.gdg.Todak.diary.dto.DiaryRequest;
-import com.gdg.Todak.diary.dto.DiarySearchRequest;
-import com.gdg.Todak.diary.dto.DiarySummaryResponse;
+import com.gdg.Todak.diary.dto.*;
 import com.gdg.Todak.diary.service.DiaryService;
 import com.gdg.Todak.member.domain.AuthenticateUser;
 import com.gdg.Todak.member.resolver.Login;
@@ -58,8 +55,8 @@ public class DiaryController {
 
     @PutMapping("/{diaryId}")
     @Operation(summary = "일기 수정하기", description = "diaryId에 해당하는 일기를 수정한다.")
-    public ApiResponse<Void> updateDiary(@Parameter(hidden = true) @Login AuthenticateUser authenticateUser, @PathVariable("diaryId") Long diaryId, @RequestBody DiaryRequest diaryRequest) {
-        diaryService.updateDiary(authenticateUser.getUsername(), diaryId, diaryRequest);
+    public ApiResponse<Void> updateDiary(@Parameter(hidden = true) @Login AuthenticateUser authenticateUser, @PathVariable("diaryId") Long diaryId, @RequestBody DiaryUpdateRequest diaryUpdateRequest) {
+        diaryService.updateDiary(authenticateUser.getUsername(), diaryId, diaryUpdateRequest);
         return ApiResponse.of(HttpStatus.OK, "수정되었습니다.");
     }
 

--- a/src/main/java/com/gdg/Todak/diary/controller/ImageController.java
+++ b/src/main/java/com/gdg/Todak/diary/controller/ImageController.java
@@ -11,6 +11,7 @@ import com.gdg.Todak.member.resolver.Login;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -27,7 +28,7 @@ public class ImageController {
 
     @PostMapping(value = "/api/v1/images/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "이미지 업로드(png, jpeg 그리고 10MB 까지 업로드 가능)", description = "로그인 필요, 파일 필수, storageUUID 필수")
-    public ApiResponse<UrlResponse> getImageUrl(@ModelAttribute ImageUploadRequest request,
+    public ApiResponse<UrlResponse> getImageUrl(@ModelAttribute @Valid ImageUploadRequest request,
                                                 @Parameter(hidden = true) @Login AuthenticateUser authenticateUser) {
         UrlResponse urlResponse = imageService.uploadImage(request.file(), request.storageUUID(), authenticateUser.getUsername());
         return ApiResponse.ok(urlResponse);
@@ -35,7 +36,7 @@ public class ImageController {
 
     @PostMapping("/api/v1/images/delete")
     @Operation(summary = "이미지 제거(업로드 API를 통해 받는 url을 body에)", description = "로그인 필요, url 필수")
-    public ApiResponse<Void> deleteImage(@RequestBody ImageDeleteRequest request,
+    public ApiResponse<Void> deleteImage(@RequestBody @Valid ImageDeleteRequest request,
                                          @Parameter(hidden = true) @Login AuthenticateUser authenticateUser) {
         imageService.deleteImage(request.url(), authenticateUser.getUsername());
         return ApiResponse.of(HttpStatus.OK, "제거가 완료되었습니다.");

--- a/src/main/java/com/gdg/Todak/diary/controller/ImageController.java
+++ b/src/main/java/com/gdg/Todak/diary/controller/ImageController.java
@@ -1,0 +1,50 @@
+package com.gdg.Todak.diary.controller;
+
+import com.gdg.Todak.common.domain.ApiResponse;
+import com.gdg.Todak.diary.dto.ImageDeleteRequest;
+import com.gdg.Todak.diary.dto.ImageUploadRequest;
+import com.gdg.Todak.diary.dto.UUIDResponse;
+import com.gdg.Todak.diary.dto.UrlResponse;
+import com.gdg.Todak.diary.service.ImageService;
+import com.gdg.Todak.member.domain.AuthenticateUser;
+import com.gdg.Todak.member.resolver.Login;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@Tag(name = "이미지 관리", description = "이미지 관련 API")
+@RequiredArgsConstructor
+public class ImageController {
+
+    private final ImageService imageService;
+
+    @PostMapping(value = "/api/v1/images/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "이미지 업로드(png, jpeg 그리고 10MB 까지 업로드 가능)", description = "로그인 필요, 파일 필수, storageUUID 필수")
+    public ApiResponse<UrlResponse> getImageUrl(@ModelAttribute ImageUploadRequest request,
+                                                @Parameter(hidden = true) @Login AuthenticateUser authenticateUser) {
+        UrlResponse urlResponse = imageService.uploadImage(request.file(), request.storageUUID(), authenticateUser.getUsername());
+        return ApiResponse.ok(urlResponse);
+    }
+
+    @PostMapping("/api/v1/images/delete")
+    @Operation(summary = "이미지 제거(업로드 API를 통해 받는 url을 body에)", description = "로그인 필요, url 필수")
+    public ApiResponse<Void> deleteImage(@RequestBody ImageDeleteRequest request,
+                                         @Parameter(hidden = true) @Login AuthenticateUser authenticateUser) {
+        imageService.deleteImage(request.url(), authenticateUser.getUsername());
+        return ApiResponse.of(HttpStatus.OK, "제거가 완료되었습니다.");
+    }
+
+    @GetMapping("/api/v1/make/uuid")
+    @Operation(summary = "storage uuid로 사용할 랜덤 uuid 생성 API", description = "uuid 생성 방식에 맞추어 랜덤값을 생성한다")
+    public ApiResponse<UUIDResponse> makeStorageUUID() {
+        String randomUUID = UUID.randomUUID().toString();
+        return ApiResponse.ok(new UUIDResponse(randomUUID));
+    }
+}

--- a/src/main/java/com/gdg/Todak/diary/controller/advice/DiaryControllerAdvice.java
+++ b/src/main/java/com/gdg/Todak/diary/controller/advice/DiaryControllerAdvice.java
@@ -7,6 +7,7 @@ import com.gdg.Todak.diary.exception.NotFoundException;
 import com.gdg.Todak.diary.exception.UnauthorizedException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -56,6 +57,15 @@ public class DiaryControllerAdvice {
         return ApiResponse.of(
                 HttpStatus.CONFLICT,
                 e.getMessage()
+        );
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(BindException.class)
+    public ApiResponse<Object> bindException(BindException e) {
+        return ApiResponse.of(
+                HttpStatus.BAD_REQUEST,
+                e.getBindingResult().getAllErrors().get(0).getDefaultMessage()
         );
     }
 }

--- a/src/main/java/com/gdg/Todak/diary/controller/advice/DiaryControllerAdvice.java
+++ b/src/main/java/com/gdg/Todak/diary/controller/advice/DiaryControllerAdvice.java
@@ -2,7 +2,7 @@ package com.gdg.Todak.diary.controller.advice;
 
 import com.gdg.Todak.common.domain.ApiResponse;
 import com.gdg.Todak.diary.exception.BadRequestException;
-import com.gdg.Todak.diary.exception.ConflictException;
+import com.gdg.Todak.diary.exception.FileException;
 import com.gdg.Todak.diary.exception.NotFoundException;
 import com.gdg.Todak.diary.exception.UnauthorizedException;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -52,8 +52,8 @@ public class DiaryControllerAdvice {
     }
 
     @ResponseStatus(HttpStatus.CONFLICT)
-    @ExceptionHandler(ConflictException.class)
-    public ApiResponse<Exception> handleConflictException(ConflictException e) {
+    @ExceptionHandler(FileException.class)
+    public ApiResponse<Exception> handleFileUploadException(FileException e) {
         return ApiResponse.of(
                 HttpStatus.CONFLICT,
                 e.getMessage()

--- a/src/main/java/com/gdg/Todak/diary/controller/advice/DiaryControllerAdvice.java
+++ b/src/main/java/com/gdg/Todak/diary/controller/advice/DiaryControllerAdvice.java
@@ -2,6 +2,7 @@ package com.gdg.Todak.diary.controller.advice;
 
 import com.gdg.Todak.common.domain.ApiResponse;
 import com.gdg.Todak.diary.exception.BadRequestException;
+import com.gdg.Todak.diary.exception.ConflictException;
 import com.gdg.Todak.diary.exception.NotFoundException;
 import com.gdg.Todak.diary.exception.UnauthorizedException;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -15,7 +16,7 @@ public class DiaryControllerAdvice {
 
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
     @ExceptionHandler(UnauthorizedException.class)
-    public ApiResponse<Exception> loginFailed(UnauthorizedException e) {
+    public ApiResponse<Exception> handleUnauthorizedException(UnauthorizedException e) {
         return ApiResponse.of(
                 HttpStatus.UNAUTHORIZED,
                 e.getMessage()
@@ -24,7 +25,7 @@ public class DiaryControllerAdvice {
 
     @ResponseStatus(HttpStatus.NOT_FOUND)
     @ExceptionHandler(NotFoundException.class)
-    public ApiResponse<Exception> encryptionFailed(NotFoundException e) {
+    public ApiResponse<Exception> handleNotFoundException(NotFoundException e) {
         return ApiResponse.of(
                 HttpStatus.NOT_FOUND,
                 e.getMessage()
@@ -33,7 +34,7 @@ public class DiaryControllerAdvice {
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(BadRequestException.class)
-    public ApiResponse<Object> bindException(BadRequestException e) {
+    public ApiResponse<Object> handleBadRequestException(BadRequestException e) {
         return ApiResponse.of(
                 HttpStatus.BAD_REQUEST,
                 e.getMessage()
@@ -46,6 +47,15 @@ public class DiaryControllerAdvice {
         return ApiResponse.of(
                 HttpStatus.CONFLICT,
                 e.getMostSpecificCause().getMessage()
+        );
+    }
+
+    @ResponseStatus(HttpStatus.CONFLICT)
+    @ExceptionHandler(ConflictException.class)
+    public ApiResponse<Exception> handleConflictException(ConflictException e) {
+        return ApiResponse.of(
+                HttpStatus.CONFLICT,
+                e.getMessage()
         );
     }
 }

--- a/src/main/java/com/gdg/Todak/diary/dto/DiaryDetailResponse.java
+++ b/src/main/java/com/gdg/Todak/diary/dto/DiaryDetailResponse.java
@@ -9,6 +9,7 @@ public record DiaryDetailResponse(
         LocalDateTime createdAt,
         String content,
         Emotion emotion,
+        String storageUUID,
         boolean isWriter
 ) {
 }

--- a/src/main/java/com/gdg/Todak/diary/dto/DiaryRequest.java
+++ b/src/main/java/com/gdg/Todak/diary/dto/DiaryRequest.java
@@ -1,12 +1,10 @@
 package com.gdg.Todak.diary.dto;
 
 import com.gdg.Todak.diary.Emotion;
-import jakarta.validation.constraints.NotEmpty;
 
 public record DiaryRequest(
         String content,
         Emotion emotion,
-        @NotEmpty
         String storageUUID
 ) {
 }

--- a/src/main/java/com/gdg/Todak/diary/dto/DiaryRequest.java
+++ b/src/main/java/com/gdg/Todak/diary/dto/DiaryRequest.java
@@ -1,9 +1,12 @@
 package com.gdg.Todak.diary.dto;
 
 import com.gdg.Todak.diary.Emotion;
+import jakarta.validation.constraints.NotEmpty;
 
 public record DiaryRequest(
         String content,
-        Emotion emotion
+        Emotion emotion,
+        @NotEmpty
+        String storageUUID
 ) {
 }

--- a/src/main/java/com/gdg/Todak/diary/dto/DiaryUpdateRequest.java
+++ b/src/main/java/com/gdg/Todak/diary/dto/DiaryUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.gdg.Todak.diary.dto;
+
+import com.gdg.Todak.diary.Emotion;
+
+public record DiaryUpdateRequest(
+        String content,
+        Emotion emotion
+) {
+}

--- a/src/main/java/com/gdg/Todak/diary/dto/ImageDeleteRequest.java
+++ b/src/main/java/com/gdg/Todak/diary/dto/ImageDeleteRequest.java
@@ -1,0 +1,9 @@
+package com.gdg.Todak.diary.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ImageDeleteRequest(
+        @NotBlank
+        String url
+) {
+}

--- a/src/main/java/com/gdg/Todak/diary/dto/ImageUploadRequest.java
+++ b/src/main/java/com/gdg/Todak/diary/dto/ImageUploadRequest.java
@@ -1,0 +1,11 @@
+package com.gdg.Todak.diary.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.web.multipart.MultipartFile;
+
+public record ImageUploadRequest(
+        MultipartFile file,
+        @NotBlank
+        String storageUUID
+) {
+}

--- a/src/main/java/com/gdg/Todak/diary/dto/UUIDResponse.java
+++ b/src/main/java/com/gdg/Todak/diary/dto/UUIDResponse.java
@@ -1,0 +1,6 @@
+package com.gdg.Todak.diary.dto;
+
+public record UUIDResponse(
+        String uuid
+) {
+}

--- a/src/main/java/com/gdg/Todak/diary/dto/UrlResponse.java
+++ b/src/main/java/com/gdg/Todak/diary/dto/UrlResponse.java
@@ -1,0 +1,6 @@
+package com.gdg.Todak.diary.dto;
+
+public record UrlResponse(
+        String url
+) {
+}

--- a/src/main/java/com/gdg/Todak/diary/entity/Diary.java
+++ b/src/main/java/com/gdg/Todak/diary/entity/Diary.java
@@ -28,6 +28,8 @@ public class Diary extends BaseEntity {
     @NotNull
     @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
+    @NotNull
+    private String storageUUID;
 
     public void updateDiary(String content, Emotion emotion) {
         this.content = content;

--- a/src/main/java/com/gdg/Todak/diary/entity/Diary.java
+++ b/src/main/java/com/gdg/Todak/diary/entity/Diary.java
@@ -4,6 +4,7 @@ import com.gdg.Todak.common.domain.BaseEntity;
 import com.gdg.Todak.diary.Emotion;
 import com.gdg.Todak.member.domain.Member;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import org.hibernate.annotations.OnDelete;
@@ -29,6 +30,7 @@ public class Diary extends BaseEntity {
     @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
     @NotNull
+    @NotEmpty
     private String storageUUID;
 
     public void updateDiary(String content, Emotion emotion) {

--- a/src/main/java/com/gdg/Todak/diary/exception/ConflictException.java
+++ b/src/main/java/com/gdg/Todak/diary/exception/ConflictException.java
@@ -1,7 +1,0 @@
-package com.gdg.Todak.diary.exception;
-
-public class ConflictException extends RuntimeException {
-    public ConflictException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/com/gdg/Todak/diary/exception/ConflictException.java
+++ b/src/main/java/com/gdg/Todak/diary/exception/ConflictException.java
@@ -1,0 +1,7 @@
+package com.gdg.Todak.diary.exception;
+
+public class ConflictException extends RuntimeException {
+    public ConflictException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/gdg/Todak/diary/exception/FileException.java
+++ b/src/main/java/com/gdg/Todak/diary/exception/FileException.java
@@ -1,0 +1,7 @@
+package com.gdg.Todak.diary.exception;
+
+public class FileException extends RuntimeException {
+    public FileException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/gdg/Todak/diary/service/ImageService.java
+++ b/src/main/java/com/gdg/Todak/diary/service/ImageService.java
@@ -3,7 +3,7 @@ package com.gdg.Todak.diary.service;
 
 import com.gdg.Todak.diary.dto.UrlResponse;
 import com.gdg.Todak.diary.exception.BadRequestException;
-import com.gdg.Todak.diary.exception.ConflictException;
+import com.gdg.Todak.diary.exception.FileException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -50,7 +50,7 @@ public class ImageService {
                 Files.createDirectories(directoryPath);
             }
         } catch (IOException e) {
-            throw new ConflictException("이미지 업로드를 실패하였습니다.");
+            throw new FileException("이미지 업로드를 실패하였습니다.");
         }
         String fileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
         File destinationFile = new File(uploadFolder + subDirectory + "/" + fileName);
@@ -59,7 +59,7 @@ public class ImageService {
             file.transferTo(destinationFile);
             return new UrlResponse(imageUrl + subDirectory + "/" + fileName);
         } catch (IOException e) {
-            throw new ConflictException("이미지 업로드를 실패하였습니다.");
+            throw new FileException("이미지 업로드를 실패하였습니다.");
         }
     }
 
@@ -71,7 +71,7 @@ public class ImageService {
         String filename = parts[5];
 
         File targetFile = new File(uploadFolder + userName + "/" + storageUUID + "/" + filename);
-        if (!targetFile.delete()) throw new ConflictException("이미지 삭제를 실패하였습니다.");
+        if (!targetFile.delete()) throw new FileException("이미지 삭제를 실패하였습니다.");
     }
 
     public void deleteAllImagesInStorageUUID(String userName, String storageUUID) {
@@ -86,10 +86,10 @@ public class ImageService {
         if (images != null) {
             for (File image : images) {
                 if (!image.delete()) {
-                    throw new ConflictException("이미지 삭제를 실패하였습니다.");
+                    throw new FileException("이미지 삭제를 실패하였습니다.");
                 }
             }
         }
-        if (!directory.delete()) throw new ConflictException("이미지 삭제를 실패하였습니다.");
+        if (!directory.delete()) throw new FileException("이미지 삭제를 실패하였습니다.");
     }
 }

--- a/src/main/java/com/gdg/Todak/diary/service/ImageService.java
+++ b/src/main/java/com/gdg/Todak/diary/service/ImageService.java
@@ -1,0 +1,95 @@
+package com.gdg.Todak.diary.service;
+
+
+import com.gdg.Todak.diary.dto.UrlResponse;
+import com.gdg.Todak.diary.exception.BadRequestException;
+import com.gdg.Todak.diary.exception.ConflictException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+    private static final List<String> ALLOWED_MIME_TYPES = Arrays.asList(
+            "image/jpeg",   // JPG 이미지
+            "image/png",    // PNG 이미지
+            "image/gif",    // GIF 이미지
+            "image/bmp",    // BMP 이미지
+            "image/webp",   // WEBP 이미지
+            "image/svg+xml" // SVG 이미지
+    );
+    private static final long MAX_FILE_SIZE = 10 * 1024 * 1024;
+    @Value("${file.path}")
+    private String uploadFolder;
+    @Value("${image.url}")
+    private String imageUrl;
+
+    public UrlResponse uploadImage(MultipartFile file, String storageUUID, String userName) {
+        if (file.isEmpty()) throw new BadRequestException("이미지가 비어있습니다.");
+        if (file.getSize() > MAX_FILE_SIZE) throw new BadRequestException("파일 크기가 10MB를 초과했습니다.");
+        if (!ALLOWED_MIME_TYPES.contains(file.getContentType()))
+            throw new BadRequestException("잘못된 형식의 이미지를 업로드하였습니다. (가능한 형식: jpg, png, gif, bmp, webp, svg)");
+
+        String subDirectory = userName + "/" + storageUUID;
+
+        try {
+            Path directoryPath = Paths.get(uploadFolder + subDirectory);
+            if (!Files.exists(directoryPath)) {
+                Files.createDirectories(directoryPath);
+            }
+        } catch (IOException e) {
+            throw new ConflictException("이미지 업로드를 실패하였습니다.");
+        }
+        String fileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
+        File destinationFile = new File(uploadFolder + subDirectory + "/" + fileName);
+
+        try {
+            file.transferTo(destinationFile);
+            return new UrlResponse(imageUrl + subDirectory + "/" + fileName);
+        } catch (IOException e) {
+            throw new ConflictException("이미지 업로드를 실패하였습니다.");
+        }
+    }
+
+    public void deleteImage(String url, String userName) {
+        // url example: /backend/images/testUser/1234/Frame.png
+        String[] parts = url.split("/");
+        if (parts.length != 6) throw new BadRequestException("입력 url 형식이 잘못되었습니다.");
+        String storageUUID = parts[4];
+        String filename = parts[5];
+
+        File targetFile = new File(uploadFolder + userName + "/" + storageUUID + "/" + filename);
+        if (!targetFile.delete()) throw new ConflictException("이미지 삭제를 실패하였습니다.");
+    }
+
+    public void deleteAllImagesInStorageUUID(String userName, String storageUUID) {
+        Path directoryPath = Paths.get(uploadFolder + userName + "/" + storageUUID);
+
+        if (!Files.exists(directoryPath)) {
+            return;
+        }
+
+        File directory = directoryPath.toFile();
+        File[] images = directory.listFiles();
+        if (images != null) {
+            for (File image : images) {
+                if (!image.delete()) {
+                    throw new ConflictException("이미지 삭제를 실패하였습니다.");
+                }
+            }
+        }
+        if (!directory.delete()) throw new ConflictException("이미지 삭제를 실패하였습니다.");
+    }
+}

--- a/src/main/java/com/gdg/Todak/friend/controller/advice/FriendControllerAdvice.java
+++ b/src/main/java/com/gdg/Todak/friend/controller/advice/FriendControllerAdvice.java
@@ -6,6 +6,7 @@ import com.gdg.Todak.friend.exception.NotFoundException;
 import com.gdg.Todak.friend.exception.UnauthorizedException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -46,6 +47,15 @@ public class FriendControllerAdvice {
         return ApiResponse.of(
                 HttpStatus.CONFLICT,
                 e.getMostSpecificCause().getMessage()
+        );
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(BindException.class)
+    public ApiResponse<Object> bindException(BindException e) {
+        return ApiResponse.of(
+                HttpStatus.BAD_REQUEST,
+                e.getBindingResult().getAllErrors().get(0).getDefaultMessage()
         );
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,7 @@ spring.sql.init.mode=always
 spring.jpa.defer-datasource-initialization=true
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
+
+# Storage
+file.path=${MOUNT_PATH}
+image.url=/backend/images/

--- a/src/test/java/com/gdg/Todak/diary/controller/DiaryControllerTest.java
+++ b/src/test/java/com/gdg/Todak/diary/controller/DiaryControllerTest.java
@@ -5,6 +5,7 @@ import com.gdg.Todak.diary.Emotion;
 import com.gdg.Todak.diary.dto.DiaryDetailResponse;
 import com.gdg.Todak.diary.dto.DiaryRequest;
 import com.gdg.Todak.diary.dto.DiarySummaryResponse;
+import com.gdg.Todak.diary.dto.DiaryUpdateRequest;
 import com.gdg.Todak.diary.service.DiaryService;
 import com.gdg.Todak.member.Interceptor.LoginCheckInterceptor;
 import com.gdg.Todak.member.domain.AuthenticateUser;
@@ -37,6 +38,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class DiaryControllerTest {
 
     private final String token = "testToken";
+    private final String storageUUID = "testUUID";
 
     @MockitoBean
     private DiaryService diaryService;
@@ -68,7 +70,7 @@ class DiaryControllerTest {
     @DisplayName("일기 작성 테스트")
     void writeDiaryTest() throws Exception {
         // given
-        DiaryRequest request = new DiaryRequest("오늘은 좋은 하루였다.", Emotion.HAPPY);
+        DiaryRequest request = new DiaryRequest("오늘은 좋은 하루였다.", Emotion.HAPPY, storageUUID);
         doNothing().when(diaryService).writeDiary(anyString(), any(DiaryRequest.class));
 
         // when
@@ -134,7 +136,7 @@ class DiaryControllerTest {
     @DisplayName("일기 상세보기 테스트")
     void getDiaryTest() throws Exception {
         // given
-        DiaryDetailResponse response = new DiaryDetailResponse(1L, LocalDateTime.of(2025, 3, 1, 12, 12, 0, 0), "오늘은 기쁜 날이다", Emotion.HAPPY, true);
+        DiaryDetailResponse response = new DiaryDetailResponse(1L, LocalDateTime.of(2025, 3, 1, 12, 12, 0, 0), "오늘은 기쁜 날이다", Emotion.HAPPY, storageUUID,true);
         when(diaryService.readDiary(anyString(), anyLong())).thenReturn(response);
 
         // when
@@ -155,8 +157,8 @@ class DiaryControllerTest {
     @DisplayName("일기 수정 테스트")
     void updateDiaryTest() throws Exception {
         // given
-        DiaryRequest request = new DiaryRequest("오늘은 슬펐다.", Emotion.SAD);
-        doNothing().when(diaryService).updateDiary(anyString(), anyLong(), any(DiaryRequest.class));
+        DiaryUpdateRequest request = new DiaryUpdateRequest("오늘은 슬펐다.", Emotion.SAD);
+        doNothing().when(diaryService).updateDiary(anyString(), anyLong(), any(DiaryUpdateRequest.class));
 
         // when
         mockMvc.perform(put("/api/v1/diary/1")

--- a/src/test/java/com/gdg/Todak/diary/controller/DiaryControllerTest.java
+++ b/src/test/java/com/gdg/Todak/diary/controller/DiaryControllerTest.java
@@ -136,7 +136,7 @@ class DiaryControllerTest {
     @DisplayName("일기 상세보기 테스트")
     void getDiaryTest() throws Exception {
         // given
-        DiaryDetailResponse response = new DiaryDetailResponse(1L, LocalDateTime.of(2025, 3, 1, 12, 12, 0, 0), "오늘은 기쁜 날이다", Emotion.HAPPY, storageUUID,true);
+        DiaryDetailResponse response = new DiaryDetailResponse(1L, LocalDateTime.of(2025, 3, 1, 12, 12, 0, 0), "오늘은 기쁜 날이다", Emotion.HAPPY, storageUUID, true);
         when(diaryService.readDiary(anyString(), anyLong())).thenReturn(response);
 
         // when

--- a/src/test/java/com/gdg/Todak/diary/controller/ImageControllerTest.java
+++ b/src/test/java/com/gdg/Todak/diary/controller/ImageControllerTest.java
@@ -1,0 +1,114 @@
+package com.gdg.Todak.diary.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gdg.Todak.diary.dto.ImageDeleteRequest;
+import com.gdg.Todak.diary.dto.UrlResponse;
+import com.gdg.Todak.diary.service.ImageService;
+import com.gdg.Todak.member.Interceptor.LoginCheckInterceptor;
+import com.gdg.Todak.member.domain.AuthenticateUser;
+import com.gdg.Todak.member.domain.Role;
+import com.gdg.Todak.member.resolver.LoginMemberArgumentResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ImageController.class)
+class ImageControllerTest {
+
+    private final String token = "testToken";
+    private final String imageUrl = "https://example.com/test-image.jpg";
+
+    @MockitoBean
+    private ImageService imageService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private LoginCheckInterceptor loginCheckInterceptor;
+
+    @MockitoBean
+    private LoginMemberArgumentResolver loginMemberArgumentResolver;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        when(loginCheckInterceptor.preHandle(any(), any(), any())).thenReturn(true);
+
+        String username = "testUser";
+        AuthenticateUser authenticateUser = new AuthenticateUser(username, Set.of(Role.USER));
+
+        when(loginMemberArgumentResolver.supportsParameter(any())).thenReturn(true);
+        when(loginMemberArgumentResolver.resolveArgument(any(), any(), any(), any())).thenReturn(authenticateUser);
+    }
+
+    @Test
+    @DisplayName("이미지 업로드 테스트")
+    void uploadImageTest() throws Exception {
+        // given
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "test.jpg", MediaType.IMAGE_JPEG_VALUE, "image-content".getBytes());
+
+        String storageUUID = "testStorageUUID";
+        UrlResponse urlResponse = new UrlResponse(imageUrl);
+
+        when(imageService.uploadImage(any(), anyString(), anyString())).thenReturn(urlResponse);
+
+        // when
+        mockMvc.perform(multipart("/api/v1/images/upload")
+                        .file(file)
+                        .param("storageUUID", storageUUID)
+                        .header("Authorization", "Bearer " + token))
+
+                //then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.url").value(imageUrl));
+    }
+
+    @Test
+    @DisplayName("이미지 삭제 테스트")
+    void deleteImageTest() throws Exception {
+        // given
+        ImageDeleteRequest request = new ImageDeleteRequest(imageUrl);
+        doNothing().when(imageService).deleteImage(anyString(), anyString());
+
+        // when
+        mockMvc.perform(post("/api/v1/images/delete")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+
+                //then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("제거가 완료되었습니다."));
+    }
+
+    @Test
+    @DisplayName("UUID 생성 테스트")
+    void generateUUIDTest() throws Exception {
+        // when
+        mockMvc.perform(get("/api/v1/make/uuid"))
+
+                //then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.uuid").isNotEmpty());
+    }
+}

--- a/src/test/java/com/gdg/Todak/diary/entity/DiaryTest.java
+++ b/src/test/java/com/gdg/Todak/diary/entity/DiaryTest.java
@@ -20,6 +20,7 @@ class DiaryTest {
                 .content("오늘 하루도 힘들었다.")
                 .emotion(Emotion.SAD)
                 .member(member)
+                .storageUUID("testUUID")
                 .build();
     }
 
@@ -30,6 +31,7 @@ class DiaryTest {
         assertThat(diary.getContent()).isEqualTo("오늘 하루도 힘들었다.");
         assertThat(diary.getEmotion()).isEqualTo(Emotion.SAD);
         assertThat(diary.getMember()).isEqualTo(member);
+        assertThat(diary.getStorageUUID()).isEqualTo("testUUID");
     }
 
     @DisplayName("일기를 수정하면 내용과 감정 상태가 변경되어야 한다")

--- a/src/test/java/com/gdg/Todak/diary/repository/DiaryRepositoryTest.java
+++ b/src/test/java/com/gdg/Todak/diary/repository/DiaryRepositoryTest.java
@@ -35,6 +35,7 @@ class DiaryRepositoryTest {
                 .member(member)
                 .content("오늘 하루도 행복했다.")
                 .emotion(Emotion.HAPPY)
+                .storageUUID("testUUID")
                 .build();
 
         // when
@@ -54,15 +55,15 @@ class DiaryRepositoryTest {
         Instant start = Instant.now().minusSeconds(86400);
         Instant end = Instant.now().plusSeconds(86400);
 
-        Diary yesterdayDiary = Diary.builder().member(member).content("어제의 일기").emotion(Emotion.HAPPY).build();
+        Diary yesterdayDiary = Diary.builder().member(member).content("어제의 일기").emotion(Emotion.HAPPY).storageUUID("testUUID").build();
         ReflectionTestUtils.setField(yesterdayDiary, "createdAt", start);
         diaryRepository.save(yesterdayDiary);
 
-        Diary todayDiary = Diary.builder().member(member).content("오늘의 일기").emotion(Emotion.HAPPY).build();
+        Diary todayDiary = Diary.builder().member(member).content("오늘의 일기").emotion(Emotion.HAPPY).storageUUID("testUUID").build();
         ReflectionTestUtils.setField(todayDiary, "createdAt", Instant.now());
         diaryRepository.save(todayDiary);
 
-        Diary tomorrowDiary = Diary.builder().member(member).content("내일의 일기").emotion(Emotion.HAPPY).build();
+        Diary tomorrowDiary = Diary.builder().member(member).content("내일의 일기").emotion(Emotion.HAPPY).storageUUID("testUUID").build();
         ReflectionTestUtils.setField(tomorrowDiary, "createdAt", end);
         diaryRepository.save(tomorrowDiary);
 
@@ -85,6 +86,7 @@ class DiaryRepositoryTest {
                 .member(member)
                 .content("오늘 하루도 행복했다.")
                 .emotion(Emotion.HAPPY)
+                .storageUUID("testUUID")
                 .build();
         ReflectionTestUtils.setField(diary, "createdAt", Instant.now());
 

--- a/src/test/java/com/gdg/Todak/diary/service/DiaryServiceTest.java
+++ b/src/test/java/com/gdg/Todak/diary/service/DiaryServiceTest.java
@@ -4,6 +4,7 @@ import com.gdg.Todak.diary.Emotion;
 import com.gdg.Todak.diary.dto.DiaryRequest;
 import com.gdg.Todak.diary.dto.DiarySearchRequest;
 import com.gdg.Todak.diary.dto.DiarySummaryResponse;
+import com.gdg.Todak.diary.dto.DiaryUpdateRequest;
 import com.gdg.Todak.diary.entity.Diary;
 import com.gdg.Todak.diary.exception.BadRequestException;
 import com.gdg.Todak.diary.exception.NotFoundException;
@@ -61,7 +62,7 @@ class DiaryServiceTest {
     @DisplayName("일기 작성 성공")
     void writeDiarySuccessfullyTest() {
         // given
-        DiaryRequest diaryRequest = new DiaryRequest("오늘은 기분이 좋다.", Emotion.HAPPY);
+        DiaryRequest diaryRequest = new DiaryRequest("오늘은 기분이 좋다.", Emotion.HAPPY, "testUUID");
 
         // when
         diaryService.writeDiary(writer.getUsername(), diaryRequest);
@@ -71,13 +72,14 @@ class DiaryServiceTest {
         assertThat(diary).isPresent();
         assertThat(diary.get().getContent()).isEqualTo("오늘은 기분이 좋다.");
         assertThat(diary.get().getEmotion()).isEqualTo(Emotion.HAPPY);
+        assertThat(diary.get().getStorageUUID()).isEqualTo("testUUID");
     }
 
     @Test
     @DisplayName("하루에 이미 작성된 일기 존재 시 작성 불가")
     void cannotWriteDiaryIfAlreadyExistsTest() {
         // given
-        DiaryRequest diaryRequest = new DiaryRequest("오늘은 기분이 좋다.", Emotion.HAPPY);
+        DiaryRequest diaryRequest = new DiaryRequest("오늘은 기분이 좋다.", Emotion.HAPPY, "testUUID");
         diaryService.writeDiary(writer.getUsername(), diaryRequest);
 
         // when & then
@@ -90,7 +92,7 @@ class DiaryServiceTest {
     @DisplayName("존재하지 않는 회원에 대한 일기 작성 시 예외 발생")
     void writeDiaryForNonExistingMemberTest() {
         // given
-        DiaryRequest diaryRequest = new DiaryRequest("오늘은 기분이 좋다.", Emotion.HAPPY);
+        DiaryRequest diaryRequest = new DiaryRequest("오늘은 기분이 좋다.", Emotion.HAPPY, "testUUID");
 
         // when & then
         assertThatThrownBy(() -> diaryService.writeDiary("nonExistentUser", diaryRequest))
@@ -106,6 +108,7 @@ class DiaryServiceTest {
                 .member(writer)
                 .content("오늘은 기분이 좋다.")
                 .emotion(Emotion.HAPPY)
+                .storageUUID("testUUID")
                 .build());
 
         // when
@@ -115,6 +118,7 @@ class DiaryServiceTest {
         assertThat(diaryDetail).isNotNull();
         assertThat(diaryDetail.content()).isEqualTo("오늘은 기분이 좋다.");
         assertThat(diaryDetail.emotion()).isEqualTo(Emotion.HAPPY);
+        assertThat(diaryDetail.storageUUID()).isEqualTo("testUUID");
         assertThat(diaryDetail.isWriter()).isTrue();
     }
 
@@ -131,6 +135,7 @@ class DiaryServiceTest {
                 .member(writer)
                 .content("자신의 3월 첫 번째 일기")
                 .emotion(Emotion.HAPPY)
+                .storageUUID("testUUID")
                 .build());
         ReflectionTestUtils.setField(diary1, "createdAt", Instant.now());
 
@@ -139,6 +144,7 @@ class DiaryServiceTest {
                 .member(writer)
                 .content("자신의 3월 두 번째 일기")
                 .emotion(Emotion.SAD)
+                .storageUUID("testUUID")
                 .build());
         ReflectionTestUtils.setField(diary2, "createdAt", Instant.now());
 
@@ -166,6 +172,7 @@ class DiaryServiceTest {
                 .member(nonWriter)
                 .content("친구의 3월 첫 번째 일기")
                 .emotion(Emotion.HAPPY)
+                .storageUUID("testUUID")
                 .build());
         ReflectionTestUtils.setField(diary1, "createdAt", Instant.now());
 
@@ -174,6 +181,7 @@ class DiaryServiceTest {
                 .member(nonWriter)
                 .content("친구의 3월 두 번째 일기")
                 .emotion(Emotion.SAD)
+                .storageUUID("testUUID")
                 .build());
         ReflectionTestUtils.setField(diary2, "createdAt", Instant.now());
 
@@ -194,6 +202,7 @@ class DiaryServiceTest {
                 .member(writer)
                 .content("오늘은 기분이 좋다.")
                 .emotion(Emotion.HAPPY)
+                .storageUUID("testUUID")
                 .build());
 
         // when
@@ -214,6 +223,7 @@ class DiaryServiceTest {
                 .member(writer)
                 .content("오늘은 기분이 좋다.")
                 .emotion(Emotion.HAPPY)
+                .storageUUID("testUUID")
                 .build());
 
         Member newMember = memberRepository.save(Member.builder()
@@ -237,9 +247,10 @@ class DiaryServiceTest {
                 .member(writer)
                 .content("오늘은 기분이 좋다.")
                 .emotion(Emotion.HAPPY)
+                .storageUUID("testUUID")
                 .build());
 
-        DiaryRequest updateRequest = new DiaryRequest("오늘은 기분이 매우 좋다.", Emotion.HAPPY);
+        DiaryUpdateRequest updateRequest = new DiaryUpdateRequest("오늘은 기분이 매우 좋다.", Emotion.HAPPY);
 
         // when
         diaryService.updateDiary(writer.getUsername(), diary.getId(), updateRequest);
@@ -259,9 +270,10 @@ class DiaryServiceTest {
                 .member(writer)
                 .content("오늘은 기분이 좋다.")
                 .emotion(Emotion.HAPPY)
+                .storageUUID("testUUID")
                 .build());
 
-        DiaryRequest updateRequest = new DiaryRequest("오늘은 기분이 별로다.", Emotion.SAD);
+        DiaryUpdateRequest updateRequest = new DiaryUpdateRequest("오늘은 기분이 별로다.", Emotion.SAD);
 
         // when & then
         assertThatThrownBy(() -> diaryService.updateDiary(nonWriter.getUsername(), diary.getId(), updateRequest))
@@ -277,6 +289,7 @@ class DiaryServiceTest {
                 .member(writer)
                 .content("오늘은 기분이 좋다.")
                 .emotion(Emotion.HAPPY)
+                .storageUUID("testUUID")
                 .build());
 
         // when
@@ -295,6 +308,7 @@ class DiaryServiceTest {
                 .member(writer)
                 .content("오늘은 기분이 좋다.")
                 .emotion(Emotion.HAPPY)
+                .storageUUID("testUUID")
                 .build());
 
         // when & then

--- a/src/test/java/com/gdg/Todak/diary/service/ImageServiceTest.java
+++ b/src/test/java/com/gdg/Todak/diary/service/ImageServiceTest.java
@@ -1,0 +1,162 @@
+package com.gdg.Todak.diary.service;
+
+import com.gdg.Todak.diary.dto.UrlResponse;
+import com.gdg.Todak.diary.exception.BadRequestException;
+import com.gdg.Todak.diary.exception.ConflictException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.TestPropertySource;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@TestPropertySource(properties = {
+        "file.path=test-uploads/",
+        "image.url=/backend/images/"
+})
+class ImageServiceTest {
+
+    @Autowired
+    private ImageService imageService;
+
+    @Value("${file.path}")
+    private String uploadFolder;
+
+    @Value("${image.url}")
+    private String imageUrl;
+
+    private AutoCloseable closeable;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        closeable = MockitoAnnotations.openMocks(this);
+
+        Path testPath = Paths.get(uploadFolder);
+        if (!Files.exists(testPath)) {
+            Files.createDirectories(testPath);
+        }
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        closeable.close();
+
+        File testDir = new File(uploadFolder);
+        if (testDir.exists() && testDir.isDirectory()) {
+            deleteFilesRecursively(testDir);
+            testDir.delete();
+        }
+    }
+
+    private void deleteFilesRecursively(File file) {
+        if (file.isDirectory()) {
+            for (File subFile : Objects.requireNonNull(file.listFiles())) {
+                deleteFilesRecursively(subFile);
+            }
+        }
+        if (file.exists()) {
+            file.delete();
+        }
+    }
+
+    @Test
+    @DisplayName("이미지 업로드 성공")
+    void uploadImageSuccessfully() {
+        // given
+        MockMultipartFile file = new MockMultipartFile(
+                "image", "test.jpg", "image/jpeg", "test data".getBytes()
+        );
+        String storageUUID = "1234";
+        String userName = "testUser";
+
+        System.out.println();
+
+        // when
+        UrlResponse response = imageService.uploadImage(file, storageUUID, userName);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.url()).startsWith(imageUrl + userName + "/" + storageUUID);
+    }
+
+    @Test
+    @DisplayName("잘못된 형식의 이미지 업로드 시 예외 발생")
+    void uploadInvalidImageFormat() {
+        // given
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "test.txt", "text/plain", "invalid file".getBytes()
+        );
+
+        // when & then
+        assertThatThrownBy(() -> imageService.uploadImage(file, "1234", "testUser"))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("잘못된 형식의 이미지를 업로드하였습니다");
+    }
+
+    @Test
+    @DisplayName("이미지 삭제 성공")
+    void deleteImageSuccessfully() throws IOException {
+        // given
+        String userName = "testUser";
+        String storageUUID = "1234";
+        String fileName = "test.jpg";
+
+        Path directoryPath = Paths.get(uploadFolder + userName + "/" + storageUUID);
+        Files.createDirectories(directoryPath);
+        Path filePath = directoryPath.resolve(fileName);
+        Files.createFile(filePath);
+
+        String fileUrl = imageUrl + userName + "/" + storageUUID + "/" + fileName;
+
+        // when
+        imageService.deleteImage(fileUrl, userName);
+
+        // then
+        assertThat(Files.exists(filePath)).isFalse();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 이미지 삭제 시 예외 발생")
+    void deleteNonExistentImage() {
+        // given
+        String fileUrl = "/backend/images/testUser/1234/nonexistent.jpg";
+
+        // when & then
+        assertThatThrownBy(() -> imageService.deleteImage(fileUrl, "testUser"))
+                .isInstanceOf(ConflictException.class)
+                .hasMessageContaining("이미지 삭제를 실패하였습니다");
+    }
+
+    @Test
+    @DisplayName("폴더 내 모든 이미지 삭제 성공")
+    void deleteAllImagesInStorageUUIDSuccessfully() throws IOException {
+        // given
+        String userName = "testUser";
+        String storageUUID = "1234";
+        Path directoryPath = Paths.get(uploadFolder + userName + "/" + storageUUID);
+        Files.createDirectories(directoryPath);
+        Files.createFile(directoryPath.resolve("test1.jpg"));
+        Files.createFile(directoryPath.resolve("test2.jpg"));
+
+        // when
+        imageService.deleteAllImagesInStorageUUID(userName, storageUUID);
+
+        // then
+        assertThat(Files.exists(directoryPath)).isFalse();
+    }
+}

--- a/src/test/java/com/gdg/Todak/diary/service/ImageServiceTest.java
+++ b/src/test/java/com/gdg/Todak/diary/service/ImageServiceTest.java
@@ -2,7 +2,7 @@ package com.gdg.Todak.diary.service;
 
 import com.gdg.Todak.diary.dto.UrlResponse;
 import com.gdg.Todak.diary.exception.BadRequestException;
-import com.gdg.Todak.diary.exception.ConflictException;
+import com.gdg.Todak.diary.exception.FileException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -138,7 +138,7 @@ class ImageServiceTest {
 
         // when & then
         assertThatThrownBy(() -> imageService.deleteImage(fileUrl, "testUser"))
-                .isInstanceOf(ConflictException.class)
+                .isInstanceOf(FileException.class)
                 .hasMessageContaining("이미지 삭제를 실패하였습니다");
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #7 

## 📝 작업 내용
- 서버에 PV, PVC, NFS를 이용하여 이미지 처리 공간을 할당
- 이미지 조회 공간 제작
- 이미지 처리 로직 추가

### 스크린샷 (선택)

로컬 테스트 결과 (마운드 없이 절대경로로)
![image](https://github.com/user-attachments/assets/f28c8103-5589-49c8-86e3-9d6944182b34)
![image](https://github.com/user-attachments/assets/64b91bde-ba95-4529-93ee-aa3d28851084)

## 💬 리뷰 요구사항(선택)
서버 쿠버네티스에 PV 8기가를 할당하고, NFS를 설치한 후 PVC를 통해 스프링어플리케이션 pod들 및 단순조회용 nginx pod와 연결했습니다.
서버에 할당된 공간을 마운트하여 각 pod들에서 사용할 수 있습니다.
aws s3 대용으로 사용한다고 생각하시면 될 것 같습니다.

관련자료 https://velog.io/@easy_ho/%EC%BF%A0%EB%B2%84%EB%84%A4%ED%8B%B0%EC%8A%A4-%EB%8B%A4%EC%A4%91-pod-%ED%99%98%EA%B2%BD%EC%97%90%EC%84%9C-%EC%82%AC%EC%9A%A9-%EA%B0%80%EB%8A%A5%ED%95%9C-%EA%B3%B5%EC%9C%A0-%EC%A0%80%EC%9E%A5%EA%B3%B5%EA%B0%84-Kubernetes%EC%97%90%EC%84%9C-PVC-PV-NFS%EC%9D%98-%EC%97%AD%ED%95%A0%EA%B3%BC-%EB%A1%9C%EC%A7%81-%ED%9D%90%EB%A6%84

> 위 글에서 /usr/share/nginx/html 부분을 저희 서버에서는 /usr/storage 로 적용하였습니다.

삭제처리를 위해 일기별 storageUUID를 프론트에서 발급받아 함께 post하도록 합의하였고, 일기가 삭제되면 해당 일기에 존재했던 이미지 파일들이 모두 삭제되어 서버 저장공간을 확보할 수 있습니다.

각자 로컬에서 테스트하기 위해서는 개발속성에서의 MOUNT_PATH를 개인 컴퓨터 폴더의 절대경로로 설정하면 됩니다.

## ⏰ 현재 버그
테스트코드 및 로컬 테스트결과 이상 없습니다.
단, ImageServiceTest에서 실제 비즈니스 로직을 주입하여 테스트용 상대 경로로 이미지 업로드 및 삭제를 진행하는데, 로컬에서는 문제 없었지만 git action내부에서도 문제 없이 파일시스템 관리가 가능할지 모르겠네요..!
이 부분은 실제 깃액션 가동 과정에서 테스트해보겠습니다.

## ✏ Git Close
close #7 