### PR TITLE
hotfix: solved bugs related with redis serializer setting

### DIFF
--- a/src/main/java/com/gdg/Todak/common/config/RedisConfig.java
+++ b/src/main/java/com/gdg/Todak/common/config/RedisConfig.java
@@ -33,8 +33,8 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, Object> redisTemplate() {
-        RedisTemplate<String, Object> template = new RedisTemplate<>();
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
         template.setConnectionFactory(connectionFactory());
 
         StringRedisSerializer stringSerializer = new StringRedisSerializer();

--- a/src/main/java/com/gdg/Todak/member/service/AuthService.java
+++ b/src/main/java/com/gdg/Todak/member/service/AuthService.java
@@ -39,7 +39,11 @@ public class AuthService {
     }
 
     private Long getMemberId(String refreshToken) {
-        return Long.parseLong((String) redisTemplate.opsForValue().get(refreshToken));
+        String memberId = (String) redisTemplate.opsForValue().get(refreshToken);
+        if (memberId == null) {
+            return null;
+        }
+        return Long.valueOf(memberId);
     }
 
     private Member getMemberById(Long memberId) {

--- a/src/main/java/com/gdg/Todak/member/service/MemberService.java
+++ b/src/main/java/com/gdg/Todak/member/service/MemberService.java
@@ -144,6 +144,6 @@ public class MemberService {
     }
 
     private void saveRefreshToken(String refreshToken, Member member) {
-        redisTemplate.opsForValue().set(refreshToken, String.valueOf(member.getId()), 14, TimeUnit.DAYS);
+        redisTemplate.opsForValue().set(refreshToken, member.getId().toString(), 14, TimeUnit.DAYS);
     }
 }

--- a/src/main/java/com/gdg/Todak/notification/controller/NotificationController.java
+++ b/src/main/java/com/gdg/Todak/notification/controller/NotificationController.java
@@ -28,7 +28,7 @@ public class NotificationController {
     }
 
     @PostMapping("/ack")
-    @Operation(summary = "읽은 알림 삭제", description = "읽은 알림을 삭제한다.")
+    @Operation(summary = "읽은 알림 삭제", description = "읽은 알림을 삭제한다. ")
     public ApiResponse notificationAck(@Parameter(hidden = true) @Login AuthenticateUser user, @RequestBody AckRequest request) {
         return ApiResponse.ok(notificationService.deleteAckNotification(user.getUserId(), request.getNotificationId()));
     }

--- a/src/main/java/com/gdg/Todak/notification/service/RedisPublisherService.java
+++ b/src/main/java/com/gdg/Todak/notification/service/RedisPublisherService.java
@@ -16,7 +16,7 @@ import java.util.concurrent.TimeUnit;
 @Service
 public class RedisPublisherService {
 
-    private final RedisTemplate<String, Object> redisTemplate;
+    private final RedisTemplate<String, String> redisTemplate;
     private final ObjectMapper objectMapper;
 
     public void publish(String channel, Object message) {

--- a/src/main/java/com/gdg/Todak/notification/service/RedisSubscriberService.java
+++ b/src/main/java/com/gdg/Todak/notification/service/RedisSubscriberService.java
@@ -25,7 +25,7 @@ import java.util.concurrent.ScheduledExecutorService;
 @Service
 public class RedisSubscriberService {
 
-    private final RedisTemplate<String, Object> redisTemplate;
+    private final RedisTemplate<String, String> redisTemplate;
     private final ObjectMapper objectMapper;
 
     private Map<String, List<SseEmitter>> emitters;

--- a/src/test/java/com/gdg/Todak/member/config/RedisConfigTest.java
+++ b/src/test/java/com/gdg/Todak/member/config/RedisConfigTest.java
@@ -31,10 +31,10 @@ class RedisConfigTest {
     @Test
     void redisRetrieveTest() {
         // given
-        redisTemplate.opsForValue().set(refreshToken, memberId, 7, TimeUnit.DAYS);
+        redisTemplate.opsForValue().set(refreshToken, memberId.toString(), 7, TimeUnit.DAYS);
 
         // when
-        Long findMemberId = (Long) redisTemplate.opsForValue().get(refreshToken);
+        Long findMemberId = Long.valueOf((String) redisTemplate.opsForValue().get(refreshToken));
 
         // then
         assertThat(findMemberId).isEqualTo(memberId);
@@ -47,10 +47,10 @@ class RedisConfigTest {
         Long memberId = 1L;
         String refreshToken = "abcd";
 
-        redisTemplate.opsForValue().set(refreshToken, memberId, 7, TimeUnit.DAYS);
+        redisTemplate.opsForValue().set(refreshToken, memberId.toString(), 7, TimeUnit.DAYS);
 
         // when
-        Long findMemberId = (Long) redisTemplate.opsForValue().get(nonExistentRefreshToken);
+        String findMemberId = (String) redisTemplate.opsForValue().get(nonExistentRefreshToken);
 
         // then
         assertThat(findMemberId).isNull();

--- a/src/test/java/com/gdg/Todak/member/service/MemberServiceTest.java
+++ b/src/test/java/com/gdg/Todak/member/service/MemberServiceTest.java
@@ -118,7 +118,7 @@ class MemberServiceTest {
         refreshToken = jwtToken.getRefreshToken();
 
         // then
-        Long memberId = (Long) redisTemplate.opsForValue().get(refreshToken);
+        Long memberId = Long.valueOf((String) redisTemplate.opsForValue().get(refreshToken));
         assertThat(memberId).isNotNull();
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #-


## 📝 작업 내용
> 알림 기능을 추가하며 redis stream을 사용했었는데, 이때 메시지 직렬화 문제 때문에 무조건 String 자료형만 저장할 수 있도록 하였습니다. 그 후 기존의 인증 기능에서 에러가 발생하여 이를 해결하기 위해 String에서 Long으로 그리고 Long에서 String으로 파싱하는 부분들을 수정하였습니다.
>
> 테스트 모두 통과하는 것 확인하였고 실제 postman을 통한 실행도 확인하였습니다.

### 스크린샷 (선택)
-

## 💬 리뷰 요구사항(선택)

> -


## ⏰ 현재 버그
-

## ✏ Git Close
> close #-
