### PR TITLE
Refactor: remove user existence check from interceptor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 
 ### dev ###
 application-dev.properties
+.DS_Store

--- a/src/main/java/com/gdg/Todak/member/Interceptor/LoginCheckInterceptor.java
+++ b/src/main/java/com/gdg/Todak/member/Interceptor/LoginCheckInterceptor.java
@@ -1,12 +1,6 @@
 package com.gdg.Todak.member.Interceptor;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.gdg.Todak.member.domain.AuthenticateUser;
-import com.gdg.Todak.member.domain.Member;
-import com.gdg.Todak.member.domain.Role;
 import com.gdg.Todak.member.exception.UnauthorizedException;
-import com.gdg.Todak.member.repository.MemberRepository;
 import com.gdg.Todak.member.util.JwtProvider;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletRequest;
@@ -15,70 +9,43 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
-import java.util.Optional;
-import java.util.Set;
-
 @RequiredArgsConstructor
 @Component
 public class LoginCheckInterceptor implements HandlerInterceptor {
 
     public static final String BEARER = "Bearer ";
+    public static final String AUTHORIZATION = "Authorization";
 
     private final JwtProvider jwtProvider;
-    private final ObjectMapper objectMapper;
-    private final MemberRepository memberRepository;
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
                              Object handler) {
 
-        String header = request.getHeader("Authorization");
+        String header = request.getHeader(AUTHORIZATION);
 
         if (isNotValidToken(header)) {
             throw new UnauthorizedException("토큰이 없거나, 헤더 형식에 맞지 않습니다.");
         }
 
-        String token = getToken(header);
-        Claims claims = jwtProvider.getClaims(token);
-        if (claims == null) {
+        if (isNotValidClaim(header)) {
             throw new UnauthorizedException("유효하지 않은 토큰입니다.");
-        }
-
-        AuthenticateUser authenticateUser = getAuthenticateUser(claims);
-
-        String userId = authenticateUser.getUserId();
-        Set<Role> roles = authenticateUser.getRoles();
-
-        Optional<Member> findMember = memberRepository.findByUserId(userId);
-        if (findMember.isEmpty()) {
-            throw new UnauthorizedException("해당 사용자가 존재하지 않습니다.");
-        }
-
-        if (invalidMemberRoles(findMember, roles)) {
-            throw new UnauthorizedException("사용자의 권한이 올바르지 않습니다.");
         }
 
         return true;
     }
 
-    private static boolean isNotValidToken(String header) {
+    private boolean isNotValidToken(String header) {
         return header == null || !header.startsWith(BEARER);
     }
 
-    private static String getToken(String header) {
+    private boolean isNotValidClaim(String header) {
+        String token = getToken(header);
+        Claims claims = jwtProvider.getClaims(token);
+        return claims == null;
+    }
+
+    private String getToken(String header) {
         return header.substring(7);
-    }
-
-    private static boolean invalidMemberRoles(Optional<Member> findMember, Set<Role> roles) {
-        return !findMember.get().getRoles().containsAll(roles);
-    }
-
-    private AuthenticateUser getAuthenticateUser(Claims claims) {
-        try {
-            String json = claims.get(jwtProvider.AUTHENTICATE_USER).toString();
-            return objectMapper.readValue(json, AuthenticateUser.class);
-        } catch (JsonProcessingException e) {
-            throw new IllegalArgumentException("토큰에서 사용자 정보를 변환할 수 없습니다.", e);
-        }
     }
 }

--- a/src/main/java/com/gdg/Todak/member/Interceptor/LoginCheckInterceptor.java
+++ b/src/main/java/com/gdg/Todak/member/Interceptor/LoginCheckInterceptor.java
@@ -1,6 +1,7 @@
 package com.gdg.Todak.member.Interceptor;
 
 import com.gdg.Todak.member.exception.UnauthorizedException;
+import com.gdg.Todak.member.util.JwtConstants;
 import com.gdg.Todak.member.util.JwtProvider;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletRequest;
@@ -9,12 +10,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
+import static com.gdg.Todak.member.util.JwtConstants.*;
+
 @RequiredArgsConstructor
 @Component
 public class LoginCheckInterceptor implements HandlerInterceptor {
-
-    public static final String BEARER = "Bearer ";
-    public static final String AUTHORIZATION = "Authorization";
 
     private final JwtProvider jwtProvider;
 
@@ -23,7 +23,6 @@ public class LoginCheckInterceptor implements HandlerInterceptor {
                              Object handler) {
 
         String header = request.getHeader(AUTHORIZATION);
-
         if (isNotValidToken(header)) {
             throw new UnauthorizedException("토큰이 없거나, 헤더 형식에 맞지 않습니다.");
         }
@@ -40,12 +39,8 @@ public class LoginCheckInterceptor implements HandlerInterceptor {
     }
 
     private boolean isNotValidClaim(String header) {
-        String token = getToken(header);
+        String token = header.substring(7);
         Claims claims = jwtProvider.getClaims(token);
         return claims == null;
-    }
-
-    private String getToken(String header) {
-        return header.substring(7);
     }
 }

--- a/src/main/java/com/gdg/Todak/member/util/JwtConstants.java
+++ b/src/main/java/com/gdg/Todak/member/util/JwtConstants.java
@@ -1,0 +1,7 @@
+package com.gdg.Todak.member.util;
+
+public class JwtConstants {
+    public static final String AUTHENTICATE_USER = "authenticateUser";
+    public static final String AUTHORIZATION = "Authorization";
+    public static final String BEARER = "Bearer ";
+}

--- a/src/main/java/com/gdg/Todak/member/util/JwtProvider.java
+++ b/src/main/java/com/gdg/Todak/member/util/JwtProvider.java
@@ -21,6 +21,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import static com.gdg.Todak.member.util.JwtConstants.AUTHENTICATE_USER;
+
 @Component
 @RequiredArgsConstructor
 public class JwtProvider {
@@ -32,8 +34,6 @@ public class JwtProvider {
 
     private byte[] secretKeyBytes;
     private Key key;
-
-    public static final String AUTHENTICATE_USER = "authenticateUser";
 
     @PostConstruct
     public void init() {

--- a/src/test/java/com/gdg/Todak/member/Interceptor/LoginCheckInterceptorTest.java
+++ b/src/test/java/com/gdg/Todak/member/Interceptor/LoginCheckInterceptorTest.java
@@ -40,12 +40,6 @@ class LoginCheckInterceptorTest {
     @Mock
     JwtProvider jwtProvider;
 
-    @Mock
-    ObjectMapper objectMapper;
-
-    @Mock
-    MemberRepository memberRepository;
-
     @InjectMocks
     LoginCheckInterceptor loginCheckInterceptor;
 
@@ -78,10 +72,6 @@ class LoginCheckInterceptorTest {
         when(request.getHeader("Authorization")).thenReturn(accessToken);
 
         when(jwtProvider.getClaims(any(String.class))).thenReturn(mockClaims);
-
-        when(objectMapper.readValue(any(String.class), eq(AuthenticateUser.class))).thenReturn(user);
-
-        when(memberRepository.findByUserId(userId)).thenReturn(Optional.of(member));
 
         // when
         boolean result = loginCheckInterceptor.preHandle(request, response, null);

--- a/src/test/java/com/gdg/Todak/member/service/AuthServiceTest.java
+++ b/src/test/java/com/gdg/Todak/member/service/AuthServiceTest.java
@@ -22,6 +22,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import static com.gdg.Todak.member.util.JwtConstants.AUTHENTICATE_USER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -93,7 +94,7 @@ class AuthServiceTest {
         Jwt newJwt = authService.updateAccessToken(updateAccessTokenServiceRequest);
 
         Claims claims = jwtProvider.getClaims(newJwt.getAccessToken());
-        String json = claims.get(jwtProvider.AUTHENTICATE_USER).toString();
+        String json = claims.get(AUTHENTICATE_USER).toString();
         AuthenticateUser authenticateUser = objectMapper.readValue(json, AuthenticateUser.class);
 
         // then


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #-


## 📝 작업 내용
인증 인터셉터에서 주로 하는 작업은 토큰의 유효성만 확인하는 것이고 사용자가 존재하는지 여부나 추가적인 비즈니스 로직은 서비스 레이어에서 처리하는 것이 맞다는 생각이 들어 인증 인터셉터에서 토큰 유효성만 확인하도록 수정하였습니다.

테스트 정상작동 확인하였습니다.

그 외에 .gitignore에 .DS_Store 파일 추가하였습니다.

### 스크린샷 (선택)
-

## 💬 리뷰 요구사항(선택)

혹시 다른 분들도 인터셉터에서 해당 유저 확인 부분을 제거하는 것이 맞다고 생각하시는지 궁금합니다.


## ⏰ 현재 버그
-

## ✏ Git Close
> close #-
