### PR TITLE
hotfix: make to return null for invalid token claims

### DIFF
--- a/.github/workflows/pr-test-quality-check.yml
+++ b/.github/workflows/pr-test-quality-check.yml
@@ -26,7 +26,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v3
       
       - name: 🧪 Run Tests with Explicit Steps
-        run: ./gradlew compileJava processResources compileTestJava processTestResources test
+        run: ./gradlew build
         env:
           REDIS_HOST: ${{ secrets.REDIS_HOST }}
           REDIS_PORT: ${{ secrets.REDIS_PORT }}

--- a/src/main/java/com/gdg/Todak/member/controller/MemberController.java
+++ b/src/main/java/com/gdg/Todak/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.gdg.Todak.member.controller.request.*;
 import com.gdg.Todak.member.domain.AuthenticateUser;
 import com.gdg.Todak.member.domain.Jwt;
 import com.gdg.Todak.member.resolver.Login;
+import com.gdg.Todak.member.service.LoginResponse;
 import com.gdg.Todak.member.service.MemberService;
 import com.gdg.Todak.member.service.response.CheckUserIdServiceResponse;
 import com.gdg.Todak.member.service.response.LogoutResponse;
@@ -40,7 +41,7 @@ public class MemberController {
 
     @PostMapping("/login")
     @Operation(summary = "로그인", description = "유저 아이디와 비밀번호로 로그인한다. 성공시 accessToken과 refreshToken이 반환된다.")
-    public ApiResponse<Jwt> login(@RequestBody LoginRequest request) {
+    public ApiResponse<LoginResponse> login(@RequestBody LoginRequest request) {
         return ApiResponse.ok(memberService.login(request.toServiceRequest()));
     }
 

--- a/src/main/java/com/gdg/Todak/member/service/LoginResponse.java
+++ b/src/main/java/com/gdg/Todak/member/service/LoginResponse.java
@@ -1,0 +1,31 @@
+package com.gdg.Todak.member.service;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginResponse {
+    private String userId;
+    private String nickname;
+    private String accessToken;
+    private String refreshToken;
+
+    @Builder
+    public LoginResponse(String userId, String nickname, String accessToken, String refreshToken) {
+        this.userId = userId;
+        this.nickname = nickname;
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+
+    public static LoginResponse of(String userId, String nickname, String accessToken, String refreshToken) {
+        return LoginResponse.builder()
+                .userId(userId)
+                .nickname(nickname)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/com/gdg/Todak/member/service/MemberService.java
+++ b/src/main/java/com/gdg/Todak/member/service/MemberService.java
@@ -1,6 +1,9 @@
 package com.gdg.Todak.member.service;
 
-import com.gdg.Todak.member.domain.*;
+import com.gdg.Todak.member.domain.AuthenticateUser;
+import com.gdg.Todak.member.domain.Member;
+import com.gdg.Todak.member.domain.MemberRole;
+import com.gdg.Todak.member.domain.Role;
 import com.gdg.Todak.member.exception.UnauthorizedException;
 import com.gdg.Todak.member.repository.MemberRepository;
 import com.gdg.Todak.member.repository.MemberRoleRepository;
@@ -67,7 +70,7 @@ public class MemberService {
     }
 
     @Transactional
-    public Jwt login(LoginServiceRequest request) {
+    public LoginResponse login(LoginServiceRequest request) {
 
         Member member = findMember(request.getUserId());
 
@@ -84,7 +87,7 @@ public class MemberService {
 
         pointService.earnAttendancePointPerDay(member);
 
-        return Jwt.of(accessToken, refreshToken);
+        return LoginResponse.of(member.getUserId(), member.getNickname(), accessToken, refreshToken);
     }
 
     public LogoutResponse logout(AuthenticateUser user, LogoutServiceRequest serviceRequest) {

--- a/src/main/java/com/gdg/Todak/member/util/JwtProvider.java
+++ b/src/main/java/com/gdg/Todak/member/util/JwtProvider.java
@@ -50,11 +50,15 @@ public class JwtProvider {
     }
 
     public Claims getClaims(String token) {
-        return Jwts.parser()
-                .verifyWith((SecretKey) key)
-                .build()
-                .parseSignedClaims(token)
-                .getPayload();
+        try {
+            return Jwts.parser()
+                    .verifyWith((SecretKey) key)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     public String createRefreshToken() {

--- a/src/test/java/com/gdg/Todak/member/service/AuthServiceTest.java
+++ b/src/test/java/com/gdg/Todak/member/service/AuthServiceTest.java
@@ -83,7 +83,7 @@ class AuthServiceTest {
                 .password(password)
                 .build();
 
-        Jwt jwt = memberService.login(loginRequest);
+        LoginResponse jwt = memberService.login(loginRequest);
         refreshToken = jwt.getRefreshToken();
 
         // when

--- a/src/test/java/com/gdg/Todak/member/service/MemberServiceTest.java
+++ b/src/test/java/com/gdg/Todak/member/service/MemberServiceTest.java
@@ -123,8 +123,8 @@ class MemberServiceTest {
         doNothing().when(pointService).earnAttendancePointPerDay(any(Member.class));
 
         // when
-        Jwt jwtToken = memberService.login(request);
-        refreshToken = jwtToken.getRefreshToken();
+        LoginResponse loginResponse = memberService.login(request);
+        refreshToken = loginResponse.getRefreshToken();
 
         // then
         Long memberId = Long.valueOf((String) redisTemplate.opsForValue().get(refreshToken));

--- a/src/test/java/com/gdg/Todak/member/util/JwtProviderTest.java
+++ b/src/test/java/com/gdg/Todak/member/util/JwtProviderTest.java
@@ -1,0 +1,67 @@
+package com.gdg.Todak.member.util;
+
+import com.gdg.Todak.member.domain.Member;
+import com.gdg.Todak.member.domain.Role;
+import io.jsonwebtoken.Claims;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Date;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@SpringBootTest
+class JwtProviderTest {
+
+    @Autowired
+    JwtProvider jwtProvider;
+
+    @DisplayName("유효한 토큰을 파싱할 시 멤버 데이터를 반환한다.")
+    @Test
+    void ValidTokenClaimParsingTest() {
+        // given
+        Member member = Member.of("userId", "userPw", "user", "userImageUrl", "userSalt");
+        Map<String, Object> claims = jwtProvider.createClaims(member, Set.of(Role.USER));
+        String accessToken = jwtProvider.createAccessToken(claims);
+
+        // when
+        Claims result = jwtProvider.getClaims(accessToken);
+
+        // then
+        assertNotNull(result);
+    }
+
+    @DisplayName("유효하지 않은 토큰을 파싱할 시 null을 반환한다.")
+    @Test
+    void InValidTokenClaimParsingTest() {
+        // given
+        String accessToken = "invalidToken";
+
+        // when
+        Claims result = jwtProvider.getClaims(accessToken);
+
+        // then
+        assertNull(result);
+    }
+
+    @DisplayName("ExpireDate가 지난 유효하지 않은 토큰을 파싱할 시 null을 반환한다.")
+    @Test
+    void InValidTokenWithExpiredDateClaimParsingTest() {
+        // given
+        Member member = Member.of("userId", "userPw", "user", "userImageUrl", "userSalt");
+        Map<String, Object> claims = jwtProvider.createClaims(member, Set.of(Role.USER));
+        String accessToken = jwtProvider.createToken(claims, new Date(System.currentTimeMillis() - 1000));
+
+        // when
+        Claims result = jwtProvider.getClaims(accessToken);
+
+        // then
+        assertNull(result);
+    }
+
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #50 


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
- jwt token claim이 유효하지 않으면 null을 반환하도록 수정
- 관련 테스트 추가
    - 정상 케이스
    - 단순 토큰 오류
    - 유효기간 지난 토큰 오류
    - LoginResponse에 userId, nickname 필드 추가

### 스크린샷 (선택)
-

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

토큰 파싱하는 부분마다 try-catch를 넣는 방법 보다 getClaims 메서드에서 null을 반환하도록 하면 기존에 구현하려 했던 의도와 모두 맞아떨어지는 것 같아 해당 부분에서 null을 반환하도록 수정하였습니다.

그런데 null을 반환한다는 것 자체가 살짝 찝찝하지만 그렇다고 optional로 감싸서 반환하기엔 그것도 추가적인 wrapper을 씌우는 것 같아서 일단은 그냥 null로 반환을 해보았습니다. 혹시 해당 방법 대신 더 나은 방법이 있을까요?


## ⏰ 현재 버그
-

## ✏ Git Close
> close #50
