### PR TITLE
feat: ai comment scheduling after writing diary

### DIFF
--- a/src/main/java/com/gdg/Todak/diary/config/SchedulerConfig.java
+++ b/src/main/java/com/gdg/Todak/diary/config/SchedulerConfig.java
@@ -1,0 +1,15 @@
+package com.gdg.Todak.diary.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+public class SchedulerConfig {
+
+    @Bean
+    public TaskScheduler taskScheduler() {
+        return new ThreadPoolTaskScheduler();
+    }
+}

--- a/src/main/java/com/gdg/Todak/diary/service/DiaryService.java
+++ b/src/main/java/com/gdg/Todak/diary/service/DiaryService.java
@@ -36,6 +36,7 @@ public class DiaryService {
     private final NotificationService notificationService;
     private final FriendCheckService friendCheckService;
     private final PointService pointService;
+    private final SchedulerService schedulerService;
 
     @Transactional
     public void writeDiary(String userId, DiaryRequest diaryRequest) {
@@ -59,6 +60,9 @@ public class DiaryService {
         Diary saveDiary = diaryRepository.save(diary);
 
         pointService.earnPointByType(new PointRequest(member, PointType.DIARY));
+
+        // AI 댓글 작성 예약
+        schedulerService.scheduleSavingCommentByAI(saveDiary);
 
         // 알림 전송
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {

--- a/src/main/java/com/gdg/Todak/diary/service/SchedulerService.java
+++ b/src/main/java/com/gdg/Todak/diary/service/SchedulerService.java
@@ -1,0 +1,33 @@
+package com.gdg.Todak.diary.service;
+
+import com.gdg.Todak.diary.entity.Diary;
+import com.gdg.Todak.diary.util.OneTimeEventScheduler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Random;
+
+@RequiredArgsConstructor
+@Service
+public class SchedulerService {
+
+    public static final int MAX_MINUTE = 20;
+
+    private final OneTimeEventScheduler oneTimeEventScheduler;
+    private final CommentService commentService;
+
+    public void scheduleSavingCommentByAI(Diary diary) {
+        LocalDateTime targetLocalDateTime = createRandomLocalDateTime();
+        oneTimeEventScheduler.schedule(() -> {
+            commentService.saveCommentByAI(diary);
+        }, targetLocalDateTime);
+    }
+
+    private static LocalDateTime createRandomLocalDateTime() {
+        long seed = System.currentTimeMillis();
+        Random rand = new Random(seed);
+
+        return LocalDateTime.now().plusMinutes(rand.nextInt(MAX_MINUTE) + 1);
+    }
+}

--- a/src/main/java/com/gdg/Todak/diary/util/OneTimeEventScheduler.java
+++ b/src/main/java/com/gdg/Todak/diary/util/OneTimeEventScheduler.java
@@ -1,0 +1,31 @@
+package com.gdg.Todak.diary.util;
+
+import com.gdg.Todak.diary.config.SchedulerConfig;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+@RequiredArgsConstructor
+@Component
+public class OneTimeEventScheduler {
+
+    private final SchedulerConfig schedulerConfig;
+    private TaskScheduler taskScheduler;
+
+    @PostConstruct
+    public void init() {
+        this.taskScheduler = schedulerConfig.taskScheduler();
+    }
+
+    public void schedule(Runnable task, LocalDateTime targetTime) {
+        Instant instant = targetTime.atZone(ZoneId.systemDefault()).toInstant();
+        taskScheduler.schedule(task, Date.from(instant));
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #-


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
- 스프링 스케줄러를 사용해서 일기 작성 후 랜덤 분 후(1~20 분)에 자동으로 댓글이 달리도록 구현하였습니다.
- 직접 테스트 완료하였고 정상 작동 확인하였습니다.
- AI 멤버는 ai_member로 만들어놓았습니다.

### 스크린샷 (선택)
1. ai_member 객체 (운영 DB)
![image](https://github.com/user-attachments/assets/d138ce89-9285-427e-8aef-5936287abc07)
2. 스케줄링 테스트
![image](https://github.com/user-attachments/assets/3a4ac1c8-bc8f-48cd-9112-791bcb42b44d)
![image](https://github.com/user-attachments/assets/596547bb-d06d-4462-8993-595a165fd02e)


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> -


## ⏰ 현재 버그
-

## ✏ Git Close
> close #-
