### PR TITLE
feat: guestbook feature added

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,6 @@ dependencies {
     // etc
     implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.7.0'
     implementation 'net.javacrumbs.shedlock:shedlock-spring:5.1.0'
-    implementation 'net.javacrumbs.shedlock:shedlock-provider-redis-spring:5.1.0'
     implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:5.1.0'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -59,15 +59,18 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-test-autoconfigure'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
-    // etc
-    implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.7.0'
-
     // monitoring
     implementation 'io.micrometer:micrometer-registry-prometheus'
 
     // AI / LangChain
     implementation 'dev.langchain4j:langchain4j:1.0.0-beta1'
     implementation 'dev.langchain4j:langchain4j-google-ai-gemini:1.0.0-beta1'
+
+    // etc
+    implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.7.0'
+    implementation 'net.javacrumbs.shedlock:shedlock-spring:5.1.0'
+    implementation 'net.javacrumbs.shedlock:shedlock-provider-redis-spring:5.1.0'
+    implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:5.1.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/gdg/Todak/common/config/ScheduleConfig.java
+++ b/src/main/java/com/gdg/Todak/common/config/ScheduleConfig.java
@@ -1,0 +1,21 @@
+package com.gdg.Todak.common.config;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+import javax.sql.DataSource;
+
+@Configuration
+@EnableScheduling
+@EnableSchedulerLock(defaultLockAtLeastFor = "30s", defaultLockAtMostFor = "1m")
+public class ScheduleConfig {
+
+    @Bean
+    public LockProvider lockProvider(DataSource dataSource) {
+        return new JdbcTemplateLockProvider(dataSource);
+    }
+}

--- a/src/main/java/com/gdg/Todak/guestbook/controller/GuestbookController.java
+++ b/src/main/java/com/gdg/Todak/guestbook/controller/GuestbookController.java
@@ -1,0 +1,37 @@
+package com.gdg.Todak.guestbook.controller;
+
+import com.gdg.Todak.common.domain.ApiResponse;
+import com.gdg.Todak.guestbook.controller.dto.AddGuestbookRequest;
+import com.gdg.Todak.guestbook.controller.dto.AddGuestbookResponse;
+import com.gdg.Todak.guestbook.controller.dto.DeleteGuestbookRequest;
+import com.gdg.Todak.guestbook.controller.dto.GetGuestbookResponse;
+import com.gdg.Todak.guestbook.service.GuestbookService;
+import com.gdg.Todak.member.domain.AuthenticateUser;
+import com.gdg.Todak.member.resolver.Login;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequestMapping("/api/v1/guestbook")
+@RequiredArgsConstructor
+@RestController
+public class GuestbookController {
+
+    private final GuestbookService guestbookService;
+
+    @GetMapping
+    public ApiResponse<List<GetGuestbookResponse>> getGuestbook(@Login AuthenticateUser user) {
+        return ApiResponse.ok(guestbookService.getGuestbook(user));
+    }
+
+    @PostMapping
+    public ApiResponse<AddGuestbookResponse> addGuestbook(@Login AuthenticateUser user, @RequestBody AddGuestbookRequest request) {
+        return ApiResponse.ok(guestbookService.addGuestbook(user, request));
+    }
+
+    @DeleteMapping
+    public ApiResponse<String> deleteGuestbook(@Login AuthenticateUser user, @RequestBody DeleteGuestbookRequest request) {
+        return ApiResponse.ok(guestbookService.deleteGuestbook(user, request));
+    }
+}

--- a/src/main/java/com/gdg/Todak/guestbook/controller/advice/GuestbookControllerAdvice.java
+++ b/src/main/java/com/gdg/Todak/guestbook/controller/advice/GuestbookControllerAdvice.java
@@ -1,0 +1,31 @@
+package com.gdg.Todak.guestbook.controller.advice;
+
+import com.gdg.Todak.common.domain.ApiResponse;
+import com.gdg.Todak.guestbook.exception.NotFoundException;
+import com.gdg.Todak.guestbook.exception.UnauthorizedException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(basePackages = "com.gdg.Todak.guestbook")
+public class GuestbookControllerAdvice {
+
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    @ExceptionHandler(UnauthorizedException.class)
+    public ApiResponse<Exception> unauthorizedException(UnauthorizedException e) {
+        return ApiResponse.of(
+            HttpStatus.UNAUTHORIZED,
+            e.getMessage()
+        );
+    }
+
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(NotFoundException.class)
+    public ApiResponse<Exception> notFoundException(NotFoundException e) {
+        return ApiResponse.of(
+            HttpStatus.NOT_FOUND,
+            e.getMessage()
+        );
+    }
+}

--- a/src/main/java/com/gdg/Todak/guestbook/controller/dto/AddGuestbookRequest.java
+++ b/src/main/java/com/gdg/Todak/guestbook/controller/dto/AddGuestbookRequest.java
@@ -1,0 +1,25 @@
+package com.gdg.Todak.guestbook.controller.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AddGuestbookRequest {
+    private String userId;
+    private String content;
+
+    @Builder
+    public AddGuestbookRequest(String userId, String content) {
+        this.userId = userId;
+        this.content = content;
+    }
+
+    public static AddGuestbookRequest of(String userId, String content) {
+        return AddGuestbookRequest.builder()
+            .userId(userId)
+            .content(content)
+            .build();
+    }
+}

--- a/src/main/java/com/gdg/Todak/guestbook/controller/dto/AddGuestbookResponse.java
+++ b/src/main/java/com/gdg/Todak/guestbook/controller/dto/AddGuestbookResponse.java
@@ -1,0 +1,33 @@
+package com.gdg.Todak.guestbook.controller.dto;
+
+import com.gdg.Todak.guestbook.entity.Guestbook;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+
+@Getter
+public class AddGuestbookResponse {
+
+    private Long id;
+    private String nickname;
+    private String content;
+    private Instant createdAt;
+
+    @Builder
+    public AddGuestbookResponse(Long id, String nickname, Instant createdAt, String content) {
+        this.id = id;
+        this.nickname = nickname;
+        this.content = content;
+        this.createdAt = createdAt;
+    }
+
+    public static AddGuestbookResponse from(Guestbook guestbook) {
+        return AddGuestbookResponse.builder()
+            .id(guestbook.getId())
+            .nickname(guestbook.getSender().getNickname())
+            .content(guestbook.getContent())
+            .createdAt(guestbook.getCreatedAt())
+            .build();
+    }
+}

--- a/src/main/java/com/gdg/Todak/guestbook/controller/dto/DeleteGuestbookRequest.java
+++ b/src/main/java/com/gdg/Todak/guestbook/controller/dto/DeleteGuestbookRequest.java
@@ -1,0 +1,23 @@
+package com.gdg.Todak.guestbook.controller.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class DeleteGuestbookRequest {
+
+    private Long guestbookId;
+
+    @Builder
+    public DeleteGuestbookRequest(Long guestbookId) {
+        this.guestbookId = guestbookId;
+    }
+
+    public static DeleteGuestbookRequest of(Long guestbookId) {
+        return DeleteGuestbookRequest.builder()
+            .guestbookId(guestbookId)
+            .build();
+    }
+}

--- a/src/main/java/com/gdg/Todak/guestbook/controller/dto/GetGuestbookResponse.java
+++ b/src/main/java/com/gdg/Todak/guestbook/controller/dto/GetGuestbookResponse.java
@@ -1,0 +1,34 @@
+package com.gdg.Todak.guestbook.controller.dto;
+
+import com.gdg.Todak.guestbook.entity.Guestbook;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@NoArgsConstructor
+@Getter
+public class GetGuestbookResponse {
+    private Long id;
+    private String nickname;
+    private String content;
+    private Instant createdAt;
+
+    @Builder
+    public GetGuestbookResponse(Long id, String nickname, String content, Instant createdAt) {
+        this.id = id;
+        this.nickname = nickname;
+        this.content = content;
+        this.createdAt = createdAt;
+    }
+
+    public static GetGuestbookResponse from(Guestbook guestbook, String nickname) {
+        return GetGuestbookResponse.builder()
+            .id(guestbook.getId())
+            .nickname(nickname)
+            .content(guestbook.getContent())
+            .createdAt(guestbook.getCreatedAt())
+            .build();
+    }
+}

--- a/src/main/java/com/gdg/Todak/guestbook/entity/Guestbook.java
+++ b/src/main/java/com/gdg/Todak/guestbook/entity/Guestbook.java
@@ -1,0 +1,54 @@
+package com.gdg.Todak.guestbook.entity;
+
+import com.gdg.Todak.common.domain.BaseEntity;
+import com.gdg.Todak.member.domain.Member;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import java.time.Instant;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class Guestbook extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @ManyToOne
+    @JoinColumn(name = "sender_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Member sender;
+    @NotNull
+    @ManyToOne
+    @JoinColumn(name = "receiver_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Member receiver;
+
+    private String content;
+
+    private Instant expiresAt;
+
+    @Builder
+    public Guestbook(Member sender, Member receiver, String content, Instant expiresAt) {
+        this.sender = sender;
+        this.receiver = receiver;
+        this.content = content;
+        this.expiresAt = expiresAt;
+    }
+
+    public static Guestbook of(Member sender, Member receiver, String content, Instant expiresAt) {
+        return Guestbook.builder()
+            .sender(sender)
+            .receiver(receiver)
+            .content(content)
+            .expiresAt(expiresAt)
+            .build();
+    }
+}

--- a/src/main/java/com/gdg/Todak/guestbook/exception/NotFoundException.java
+++ b/src/main/java/com/gdg/Todak/guestbook/exception/NotFoundException.java
@@ -1,0 +1,7 @@
+package com.gdg.Todak.guestbook.exception;
+
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/gdg/Todak/guestbook/exception/UnauthorizedException.java
+++ b/src/main/java/com/gdg/Todak/guestbook/exception/UnauthorizedException.java
@@ -1,0 +1,7 @@
+package com.gdg.Todak.guestbook.exception;
+
+public class UnauthorizedException extends RuntimeException {
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/gdg/Todak/guestbook/repository/GuestbookRepository.java
+++ b/src/main/java/com/gdg/Todak/guestbook/repository/GuestbookRepository.java
@@ -1,0 +1,22 @@
+package com.gdg.Todak.guestbook.repository;
+
+import com.gdg.Todak.guestbook.entity.Guestbook;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.util.List;
+
+@Repository
+public interface GuestbookRepository extends JpaRepository<Guestbook, Long> {
+
+    @Query("SELECT g FROM Guestbook g WHERE g.receiver.userId = :receiverUserId AND g.createdAt < g.expiresAt")
+    List<Guestbook> findValidGuestbooksByReceiverUserId(@Param("receiverUserId") String receiverUserId);
+
+    @Modifying
+    @Query("DELETE FROM Guestbook g WHERE g.expiresAt < :instant")
+    void deleteAllExpiredGuestbooks(@Param("instant") Instant instant);
+}

--- a/src/main/java/com/gdg/Todak/guestbook/scheduler/GuestbookScheduler.java
+++ b/src/main/java/com/gdg/Todak/guestbook/scheduler/GuestbookScheduler.java
@@ -1,0 +1,23 @@
+package com.gdg.Todak.guestbook.scheduler;
+
+import com.gdg.Todak.guestbook.service.GuestbookService;
+import lombok.RequiredArgsConstructor;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+
+@Component
+@RequiredArgsConstructor
+public class GuestbookScheduler {
+
+    private final GuestbookService guestbookService;
+
+    @SchedulerLock(name = "guestbook_delete_cron_lock", lockAtLeastFor = "30s", lockAtMostFor = "5m")
+    @Scheduled(cron = "0 0 * * * *")
+    public void deleteExpiredGuestbooks() {
+        Instant now = Instant.now();
+        guestbookService.deleteExpiredGuestbooks(now);
+    }
+}

--- a/src/main/java/com/gdg/Todak/guestbook/service/GuestbookService.java
+++ b/src/main/java/com/gdg/Todak/guestbook/service/GuestbookService.java
@@ -1,0 +1,92 @@
+package com.gdg.Todak.guestbook.service;
+
+import com.gdg.Todak.guestbook.controller.dto.AddGuestbookRequest;
+import com.gdg.Todak.guestbook.controller.dto.AddGuestbookResponse;
+import com.gdg.Todak.guestbook.controller.dto.DeleteGuestbookRequest;
+import com.gdg.Todak.guestbook.controller.dto.GetGuestbookResponse;
+import com.gdg.Todak.guestbook.entity.Guestbook;
+import com.gdg.Todak.guestbook.exception.NotFoundException;
+import com.gdg.Todak.guestbook.exception.UnauthorizedException;
+import com.gdg.Todak.guestbook.repository.GuestbookRepository;
+import com.gdg.Todak.member.domain.AuthenticateUser;
+import com.gdg.Todak.member.domain.Member;
+import com.gdg.Todak.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class GuestbookService {
+
+    public static final int EXPIRE_DAY = 1;
+
+    private final GuestbookRepository guestbookRepository;
+    private final MemberRepository memberRepository;
+
+    public List<GetGuestbookResponse> getGuestbook(AuthenticateUser user) {
+        Member member = getMember(user.getUserId());
+
+        return guestbookRepository.findValidGuestbooksByReceiverUserId(member.getUserId()).stream()
+            .map(guestbook -> GetGuestbookResponse.from(guestbook, member.getNickname()))
+            .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public AddGuestbookResponse addGuestbook(AuthenticateUser user, AddGuestbookRequest request) {
+        Member sender = getMember(user.getUserId());
+        Member receiver = getMember(request.getUserId());
+
+        Instant expiresAt = Instant.now().plus(EXPIRE_DAY, ChronoUnit.DAYS);
+
+        Guestbook guestbook = Guestbook.of(sender, receiver, request.getContent(), expiresAt);
+
+        return AddGuestbookResponse.from(guestbookRepository.save(guestbook));
+    }
+
+    @Transactional
+    public String deleteGuestbook(AuthenticateUser user, DeleteGuestbookRequest request) {
+        Member member = getMember(user.getUserId());
+
+        Guestbook guestbook = getGuestbook(request);
+
+        if (isNotGuestbookOwner(member, guestbook)) {
+            throw new UnauthorizedException("방명록 주인이 아닙니다.");
+        }
+
+        guestbookRepository.delete(guestbook);
+
+        return "방명록이 삭제되었습니다.";
+    }
+
+    @Transactional
+    public void deleteExpiredGuestbooks(Instant now) {
+        guestbookRepository.deleteAllExpiredGuestbooks(now);
+    }
+
+    private static boolean isNotGuestbookOwner(Member sender, Guestbook guestbook) {
+        return !sender.getUserId().equals(guestbook.getReceiver().getUserId());
+    }
+
+    private Guestbook getGuestbook(DeleteGuestbookRequest request) {
+        Optional<Guestbook> guestbookOptional = guestbookRepository.findById(request.getGuestbookId());
+
+        if (guestbookOptional.isEmpty()) {
+            throw new NotFoundException("존재하지 않는 방명록 입니다.");
+        }
+
+        return guestbookOptional.get();
+    }
+
+    private Member getMember(String userId) {
+        return memberRepository.findByUserId(userId)
+            .orElseThrow(() -> new NotFoundException("멤버가 존재하지 않습니다."));
+    }
+}

--- a/src/main/java/com/gdg/Todak/member/domain/AuthenticateUser.java
+++ b/src/main/java/com/gdg/Todak/member/domain/AuthenticateUser.java
@@ -18,4 +18,11 @@ public class AuthenticateUser {
         this.userId = userId;
         this.roles = roles;
     }
+
+    public static AuthenticateUser of(String userId, Set<Role> roles) {
+        return AuthenticateUser.builder()
+            .userId(userId)
+            .roles(roles)
+            .build();
+    }
 }

--- a/src/test/java/com/gdg/Todak/guestbook/repository/GuestbookRepositoryTest.java
+++ b/src/test/java/com/gdg/Todak/guestbook/repository/GuestbookRepositoryTest.java
@@ -1,0 +1,81 @@
+package com.gdg.Todak.guestbook.repository;
+
+import com.gdg.Todak.guestbook.entity.Guestbook;
+import com.gdg.Todak.member.domain.Member;
+import com.gdg.Todak.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+@SpringBootTest
+class GuestbookRepositoryTest {
+
+    @Autowired
+    GuestbookRepository guestbookRepository;
+    @Autowired
+    MemberRepository memberRepository;
+
+    @DisplayName("receiver의 userId에 해당하는 방명록들을 모두 가져온다.")
+    @Test
+    void findValidGuestbooksByReceiverUserIdTest() {
+        // given
+        Member sender = Member.of("userId1", "password", "nickname1", "imageUrl", "salt");
+
+        String receiverUserId = "userId2";
+        Member receiver = Member.of(receiverUserId, "password", "nickname2", "imageUrl", "salt");
+
+        memberRepository.saveAll(List.of(sender, receiver));
+
+        String testContent = "test_content";
+
+        Instant now = Instant.now();
+        Guestbook guestbook1 = new Guestbook(sender, receiver, testContent, now.plus(1, ChronoUnit.DAYS));
+        Guestbook guestbook2 = new Guestbook(sender, receiver, testContent, now.plus(-1, ChronoUnit.DAYS));
+
+        guestbookRepository.saveAll(List.of(guestbook1, guestbook2));
+
+        // when
+        List<Guestbook> findGuestbooks = guestbookRepository.findValidGuestbooksByReceiverUserId(receiverUserId);
+
+        // then
+        assertThat(findGuestbooks).hasSize(1)
+            .extracting(Guestbook::getContent)
+            .containsExactly(testContent);
+    }
+
+    @DisplayName("만료된 방명록들을 모두 삭제한다.")
+    @Test
+    void deleteAllExpiredGuestbooksTest() {
+        // given
+        Member sender = Member.of("userId1", "password", "nickname1", "imageUrl", "salt");
+
+        Member receiver = Member.of("userId2", "password", "nickname2", "imageUrl", "salt");
+
+        memberRepository.saveAll(List.of(sender, receiver));
+
+        String testContent = "test_content";
+
+        Instant now = Instant.now();
+        Guestbook guestbook1 = new Guestbook(sender, receiver, testContent, now.plus(-1, ChronoUnit.DAYS));
+        Guestbook guestbook2 = new Guestbook(sender, receiver, testContent, now.plus(-1, ChronoUnit.DAYS));
+
+        guestbookRepository.saveAll(List.of(guestbook1, guestbook2));
+
+        // when
+        guestbookRepository.deleteAllExpiredGuestbooks(now);
+
+        // then
+        List<Guestbook> guestbooks = guestbookRepository.findAll();
+        assertThat(guestbooks).hasSize(0);
+    }
+
+}

--- a/src/test/java/com/gdg/Todak/guestbook/service/GuestbookServiceTest.java
+++ b/src/test/java/com/gdg/Todak/guestbook/service/GuestbookServiceTest.java
@@ -1,0 +1,145 @@
+package com.gdg.Todak.guestbook.service;
+
+import com.gdg.Todak.guestbook.controller.dto.AddGuestbookRequest;
+import com.gdg.Todak.guestbook.controller.dto.AddGuestbookResponse;
+import com.gdg.Todak.guestbook.controller.dto.DeleteGuestbookRequest;
+import com.gdg.Todak.guestbook.controller.dto.GetGuestbookResponse;
+import com.gdg.Todak.guestbook.entity.Guestbook;
+import com.gdg.Todak.guestbook.exception.NotFoundException;
+import com.gdg.Todak.guestbook.exception.UnauthorizedException;
+import com.gdg.Todak.guestbook.repository.GuestbookRepository;
+import com.gdg.Todak.member.domain.AuthenticateUser;
+import com.gdg.Todak.member.domain.Member;
+import com.gdg.Todak.member.domain.Role;
+import com.gdg.Todak.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Transactional
+@SpringBootTest
+class GuestbookServiceTest {
+
+    @Autowired
+    GuestbookService guestbookService;
+    @Autowired
+    GuestbookRepository guestbookRepository;
+    @Autowired
+    MemberRepository memberRepository;
+
+    String testContent;
+    String senderUserId;
+    String receiverUserId;
+
+    Member sender;
+    Member receiver;
+
+
+    @BeforeEach
+    void setUp() {
+        testContent = "testContent";
+
+        senderUserId = "userId1";
+        sender = Member.of(senderUserId, "password", "nickname1", "imageUrl", "salt");
+
+        receiverUserId = "userId2";
+        receiver = Member.of(receiverUserId, "password", "nickname2", "imageUrl", "salt");
+
+        memberRepository.saveAll(List.of(sender, receiver));
+    }
+
+    @DisplayName("방명록을 조회한다.")
+    @Test
+    void getGuestbookTest() {
+        // given
+        Guestbook guestbook = new Guestbook(sender, receiver, testContent, Instant.now().plus(1, ChronoUnit.DAYS));
+        guestbookRepository.save(guestbook);
+
+        AuthenticateUser authenticateUser = AuthenticateUser.of(receiverUserId, Set.of(Role.USER));
+
+        // when
+        List<GetGuestbookResponse> findGuestbooks = guestbookService.getGuestbook(authenticateUser);
+
+        // then
+        assertThat(findGuestbooks).hasSize(1)
+            .extracting(GetGuestbookResponse::getContent)
+            .containsExactly(testContent);
+    }
+
+    @DisplayName("방명록을 추가한다.")
+    @Test
+    void addGuestbookTest() {
+        // given
+        AddGuestbookRequest request = AddGuestbookRequest.of(receiverUserId, testContent);
+
+        AuthenticateUser authenticateUser = AuthenticateUser.of(receiverUserId, Set.of(Role.USER));
+
+        // when
+        AddGuestbookResponse response = guestbookService.addGuestbook(authenticateUser, request);
+
+        // then
+        assertThat(response.getContent()).isEqualTo(testContent);
+    }
+
+    @DisplayName("방명록을 삭제한다.")
+    @Test
+    void deleteGuestbookTest() {
+        // given
+        Guestbook guestbook = new Guestbook(sender, receiver, testContent, Instant.now().plus(1, ChronoUnit.DAYS));
+        Guestbook saveGuestbook = guestbookRepository.save(guestbook);
+
+        DeleteGuestbookRequest request = DeleteGuestbookRequest.of(saveGuestbook.getId());
+
+        AuthenticateUser authenticateUser = AuthenticateUser.of(receiverUserId, Set.of(Role.USER));
+
+        // when
+        guestbookService.deleteGuestbook(authenticateUser, request);
+
+        Optional<Guestbook> findGuestbook = guestbookRepository.findById(saveGuestbook.getId());
+
+        // then
+        assertThat(findGuestbook).isEmpty();
+    }
+
+    @DisplayName("존재하지 않는 방명록을 삭제하면 예외가 발생한다.")
+    @Test
+    void deleteNonexistentGuestbookTest() {
+        // given
+        DeleteGuestbookRequest request = DeleteGuestbookRequest.of(-1L);
+
+        AuthenticateUser authenticateUser = AuthenticateUser.of(receiverUserId, Set.of(Role.USER));
+
+        // when // then
+        assertThatThrownBy(() -> guestbookService.deleteGuestbook(authenticateUser, request))
+            .isInstanceOf(NotFoundException.class);
+    }
+
+    @DisplayName("방명록 주인이 아닌 사람이 방명록을 삭제하면 예외가 발생한다.")
+    @Test
+    void deleteByNotOwnerGuestbookTest() {
+        // given
+        Guestbook guestbook = new Guestbook(sender, receiver, testContent, Instant.now().plus(1, ChronoUnit.DAYS));
+        Guestbook saveGuestbook = guestbookRepository.save(guestbook);
+
+        DeleteGuestbookRequest request = DeleteGuestbookRequest.of(saveGuestbook.getId());
+
+        AuthenticateUser notOwnerAuthenticateUser = AuthenticateUser.of(senderUserId, Set.of(Role.USER));
+
+        // when // then
+        assertThatThrownBy(() -> guestbookService.deleteGuestbook(notOwnerAuthenticateUser, request))
+            .isInstanceOf(UnauthorizedException.class);
+    }
+
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #-


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
- 방명록 CRD 기능을 구현하였습니다.
- 만료기간(생성 후 1일)이 지나지 않은 데이터만 가져올 수 있도록 커스텀 쿼리를 작성하였습니다.
- 레디스 ttl보다 관계형 DB가 데이터 조건 탐색 시 얻는 장점이 더 큰것 같아 관계형 데이터 + 만료기간 설정 후 스프링 스케줄러로 일정 시간마다 만료데이터들이 삭제되게 구현하였습니다.
- 실제 운영 서버에서는 3개의 pod가 돌아가고 있어 스프링 스케줄러의 중복 실행이 생깁니다. 이를 해결하기 위해 shedlock을 적용하여 하나의 pod에서만 스프링 스케줄러가 실행되도록 하였습니다.
- shedlock 정상 작동 로컬에서 2개의 서버를 서로 다른 포트에서 띄워서 확인하였습니다.
- shedlock 참고
    - https://minhye0k.github.io/shedlock-%EC%9D%84-%EC%9D%B4%EC%9A%A9%ED%95%B4-spring-scheduler-%EC%A4%91%EB%B3%B5-%EC%8B%A4%ED%96%89%EC%9D%84-%EB%A9%88%EC%B6%B0%EB%B3%B4%EC%9E%90

### 스크린샷 (선택)
-

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> -


## ⏰ 현재 버그
-

## ✏ Git Close
> close #-
