### PR TITLE
Feat: Integrate the API for pending friend requests and friend requests in rejected status and separate them into requester and acceptor positions.

### DIFF
--- a/src/main/java/com/gdg/Todak/friend/controller/FriendController.java
+++ b/src/main/java/com/gdg/Todak/friend/controller/FriendController.java
@@ -1,10 +1,7 @@
 package com.gdg.Todak.friend.controller;
 
 import com.gdg.Todak.common.domain.ApiResponse;
-import com.gdg.Todak.friend.dto.FriendCountResponse;
-import com.gdg.Todak.friend.dto.FriendIdRequest;
-import com.gdg.Todak.friend.dto.FriendRequestResponse;
-import com.gdg.Todak.friend.dto.FriendResponse;
+import com.gdg.Todak.friend.dto.*;
 import com.gdg.Todak.friend.service.FriendService;
 import com.gdg.Todak.member.domain.AuthenticateUser;
 import com.gdg.Todak.member.resolver.Login;
@@ -40,17 +37,24 @@ public class FriendController {
         return ApiResponse.ok(friendResponses);
     }
 
-    @Operation(summary = "대기중인 친구 요청들 확인", description = "본인에게 온 친구 요청 대기 목록을 확인합니다.")
+    @Operation(summary = "대기중인 친구 요청들 확인", description = "친구 요청 대기 목록을 확인합니다.")
     @GetMapping("/pending")
     public ApiResponse<List<FriendRequestResponse>> getAllPendingFriendRequest(@Parameter(hidden = true) @Login AuthenticateUser authenticateUser) {
         List<FriendRequestResponse> friendRequestResponses = friendService.getAllFriendRequests(authenticateUser.getUserId());
         return ApiResponse.ok(friendRequestResponses);
     }
 
-    @Operation(summary = "거절한 친구 요청들 확인", description = "본인에게 온 친구 요청 중 거절한 요청 목록을 확인합니다.")
-    @GetMapping("/declined")
-    public ApiResponse<List<FriendRequestResponse>> getAllDeclinedFriendRequest(@Parameter(hidden = true) @Login AuthenticateUser authenticateUser) {
-        List<FriendRequestResponse> friendRequestResponses = friendService.getAllDeclinedFriends(authenticateUser.getUserId());
+    @Operation(summary = "보낸 친구 요청들 확인", description = "본인이 보낸 친구 요청들 중 대기중, 거절된 친구 요청들을 확인합니다.")
+    @GetMapping("/requester")
+    public ApiResponse<List<FriendRequestWithStatusResponse>> getAllPendingAndDeclinedFriendRequestByRequester(@Parameter(hidden = true) @Login AuthenticateUser authenticateUser) {
+        List<FriendRequestWithStatusResponse> friendRequestResponses = friendService.getAllPendingAndDeclinedFriendRequestByRequester(authenticateUser.getUserId());
+        return ApiResponse.ok(friendRequestResponses);
+    }
+
+    @Operation(summary = "받은 친구 요청들 확인", description = "본인이 받은 친구 요청들 중 대기중, 거절된 친구 요청들을 확인합니다.")
+    @GetMapping("/accepter")
+    public ApiResponse<List<FriendRequestWithStatusResponse>> getAllPendingAndDeclinedFriendRequestByAccepter(@Parameter(hidden = true) @Login AuthenticateUser authenticateUser) {
+        List<FriendRequestWithStatusResponse> friendRequestResponses = friendService.getAllPendingAndDeclinedFriendRequestByAccepter(authenticateUser.getUserId());
         return ApiResponse.ok(friendRequestResponses);
     }
 

--- a/src/main/java/com/gdg/Todak/friend/dto/FriendRequestWithStatusResponse.java
+++ b/src/main/java/com/gdg/Todak/friend/dto/FriendRequestWithStatusResponse.java
@@ -1,0 +1,11 @@
+package com.gdg.Todak.friend.dto;
+
+import com.gdg.Todak.friend.FriendStatus;
+
+public record FriendRequestWithStatusResponse(
+        Long friendRequestId,
+        String requesterName,
+        String accepterName,
+        FriendStatus friendStatus
+) {
+}

--- a/src/main/java/com/gdg/Todak/friend/repository/FriendRepository.java
+++ b/src/main/java/com/gdg/Todak/friend/repository/FriendRepository.java
@@ -18,6 +18,10 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
     List<Friend> findAllByAccepterUserIdAndFriendStatusOrRequesterUserIdAndFriendStatus
             (String accepterName, FriendStatus friendStatus1, String requesterName, FriendStatus friendStatus2);
 
+    List<Friend> findAllByAccepterUserIdAndFriendStatusIn(String accepterName, List<FriendStatus> friendStatuses);
+
+    List<Friend> findAllByRequesterUserIdAndFriendStatusIn(String requesterName, List<FriendStatus> friendStatuses);
+
     @Query("SELECT COUNT(f) FROM Friend f WHERE f.requester = :member AND f.friendStatus IN :statuses")
     long countByRequesterAndStatusIn(@Param("member") Member member, @Param("statuses") List<FriendStatus> statuses);
 

--- a/src/main/java/com/gdg/Todak/friend/service/FriendService.java
+++ b/src/main/java/com/gdg/Todak/friend/service/FriendService.java
@@ -1,10 +1,7 @@
 package com.gdg.Todak.friend.service;
 
 import com.gdg.Todak.friend.FriendStatus;
-import com.gdg.Todak.friend.dto.FriendCountResponse;
-import com.gdg.Todak.friend.dto.FriendIdRequest;
-import com.gdg.Todak.friend.dto.FriendRequestResponse;
-import com.gdg.Todak.friend.dto.FriendResponse;
+import com.gdg.Todak.friend.dto.*;
 import com.gdg.Todak.friend.entity.Friend;
 import com.gdg.Todak.friend.exception.BadRequestException;
 import com.gdg.Todak.friend.exception.NotFoundException;
@@ -76,15 +73,28 @@ public class FriendService {
                 .collect(Collectors.toList());
     }
 
-    public List<FriendRequestResponse> getAllDeclinedFriends(String userId) {
-        return friendRepository.findAllByAccepterUserIdAndFriendStatusOrRequesterUserIdAndFriendStatus(userId, FriendStatus.DECLINED, userId, FriendStatus.DECLINED)
+    public List<FriendRequestWithStatusResponse> getAllPendingAndDeclinedFriendRequestByRequester(String userId) {
+        return friendRepository.findAllByRequesterUserIdAndFriendStatusIn(userId, List.of(FriendStatus.PENDING, FriendStatus.DECLINED))
                 .stream().map(
-                        Friend -> new FriendRequestResponse(
+                        Friend -> new FriendRequestWithStatusResponse(
                                 Friend.getId(),
                                 Friend.getRequester().getUserId(),
-                                Friend.getAccepter().getUserId()
+                                Friend.getAccepter().getUserId(),
+                                Friend.getFriendStatus()
                         ))
-                .collect(Collectors.toList());
+                .toList();
+    }
+
+    public List<FriendRequestWithStatusResponse> getAllPendingAndDeclinedFriendRequestByAccepter(String userId) {
+        return friendRepository.findAllByAccepterUserIdAndFriendStatusIn(userId, List.of(FriendStatus.PENDING, FriendStatus.DECLINED))
+                .stream().map(
+                        Friend -> new FriendRequestWithStatusResponse(
+                                Friend.getId(),
+                                Friend.getRequester().getUserId(),
+                                Friend.getAccepter().getUserId(),
+                                Friend.getFriendStatus()
+                        ))
+                .toList();
     }
 
     public List<FriendRequestResponse> getAllFriendRequests(String userId) {

--- a/src/test/java/com/gdg/Todak/friend/service/FriendServiceTest.java
+++ b/src/test/java/com/gdg/Todak/friend/service/FriendServiceTest.java
@@ -1,7 +1,7 @@
 package com.gdg.Todak.friend.service;
 
 import com.gdg.Todak.friend.FriendStatus;
-import com.gdg.Todak.friend.dto.FriendIdRequest;
+import com.gdg.Todak.friend.dto.*;
 import com.gdg.Todak.friend.entity.Friend;
 import com.gdg.Todak.friend.exception.BadRequestException;
 import com.gdg.Todak.friend.repository.FriendRepository;
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -185,5 +186,128 @@ class FriendServiceTest {
         assertThatThrownBy(() -> friendService.makeFriendRequest(requester.getUserId(), request))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage("상대방이 더 이상 친구 요청을 받을 수 없습니다. (최대 20개)");
+    }
+
+    @Test
+    @DisplayName("모든 친구 조회")
+    void getAllFriendTest() {
+        //given
+        Friend friend = friendRepository.save(Friend.builder().requester(requester).accepter(accepter).friendStatus(FriendStatus.ACCEPTED).build());
+
+        //when
+        List<FriendResponse> friendResponses = friendService.getAllFriend(requester.getUserId());
+
+        //then
+        assertThat(friendResponses).hasSize(1);
+        assertThat(friendResponses.get(0).friendId()).isEqualTo(accepter.getUserId());
+    }
+
+    @Test
+    @DisplayName("본인이 보낸 대기 및 거절된 친구 요청 조회")
+    void getAllPendingAndDeclinedFriendRequestByRequesterTest() {
+        //given
+        Friend pendingFriend = friendRepository.save(Friend.builder()
+                .requester(requester)
+                .accepter(accepter)
+                .friendStatus(FriendStatus.PENDING)
+                .build());
+
+        Member anotherAccepter = memberRepository.save(new Member("another", "test3", "test3", "test3", "test3"));
+        Friend declinedFriend = friendRepository.save(Friend.builder()
+                .requester(requester)
+                .accepter(anotherAccepter)
+                .friendStatus(FriendStatus.DECLINED)
+                .build());
+
+        //when
+        List<FriendRequestWithStatusResponse> friendRequestResponses =
+                friendService.getAllPendingAndDeclinedFriendRequestByRequester(requester.getUserId());
+
+        //then
+        assertThat(friendRequestResponses).hasSize(2);
+        assertThat(friendRequestResponses.stream().map(FriendRequestWithStatusResponse::friendStatus))
+                .containsExactlyInAnyOrder(FriendStatus.PENDING, FriendStatus.DECLINED);
+    }
+
+    @Test
+    @DisplayName("본인이 받은 대기 및 거절된 친구 요청 조회")
+    void getAllPendingAndDeclinedFriendRequestByAccepterTest() {
+        //given
+        Friend pendingFriend = friendRepository.save(Friend.builder()
+                .requester(accepter)
+                .accepter(requester)
+                .friendStatus(FriendStatus.PENDING)
+                .build());
+
+        Member anotherRequester = memberRepository.save(new Member("another", "test3", "test3", "test3", "test3"));
+        Friend declinedFriend = friendRepository.save(Friend.builder()
+                .requester(anotherRequester)
+                .accepter(requester)
+                .friendStatus(FriendStatus.DECLINED)
+                .build());
+
+        //when
+        List<FriendRequestWithStatusResponse> friendRequestResponses =
+                friendService.getAllPendingAndDeclinedFriendRequestByAccepter(requester.getUserId());
+
+        //then
+        assertThat(friendRequestResponses).hasSize(2);
+        assertThat(friendRequestResponses.stream().map(FriendRequestWithStatusResponse::friendStatus))
+                .containsExactlyInAnyOrder(FriendStatus.PENDING, FriendStatus.DECLINED);
+    }
+
+    @Test
+    @DisplayName("모든 대기중인 친구 요청 조회")
+    void getAllFriendRequestsTest() {
+        //given
+        Friend pendingRequest = friendRepository.save(Friend.builder()
+                .requester(accepter)
+                .accepter(requester)
+                .friendStatus(FriendStatus.PENDING)
+                .build());
+
+        //when
+        List<FriendRequestResponse> friendRequestResponses = friendService.getAllFriendRequests(requester.getUserId());
+
+        //then
+        assertThat(friendRequestResponses).hasSize(1);
+        assertThat(friendRequestResponses.get(0).requesterName()).isEqualTo(accepter.getUserId());
+        assertThat(friendRequestResponses.get(0).accepterName()).isEqualTo(requester.getUserId());
+    }
+
+    @Test
+    @DisplayName("사용자의 친구 및 친구 요청 개수 조회")
+    void getMyFriendCountByStatusTest() {
+        //given
+        // 대기 중인 요청
+        Friend pendingFriend1 = friendRepository.save(Friend.builder()
+                .requester(requester)
+                .accepter(accepter)
+                .friendStatus(FriendStatus.PENDING)
+                .build());
+
+        // 수락된 요청
+        Member anotherAccepter = memberRepository.save(new Member("another", "test3", "test3", "test3", "test3"));
+        Friend acceptedFriend = friendRepository.save(Friend.builder()
+                .requester(requester)
+                .accepter(anotherAccepter)
+                .friendStatus(FriendStatus.ACCEPTED)
+                .build());
+
+        //when
+        List<FriendCountResponse> friendCountResponses = friendService.getMyFriendCountByStatus(requester.getUserId());
+
+        //then
+        assertThat(friendCountResponses).hasSize(2);
+        assertThat(friendCountResponses.stream()
+                .filter(resp -> resp.friendStatus() == FriendStatus.PENDING)
+                .findFirst()
+                .orElseThrow()
+                .count()).isEqualTo(1);
+        assertThat(friendCountResponses.stream()
+                .filter(resp -> resp.friendStatus() == FriendStatus.ACCEPTED)
+                .findFirst()
+                .orElseThrow()
+                .count()).isEqualTo(1);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #77 

## 📝 작업 내용
- Integrate the API for pending friend requests and friend requests in rejected status and separate them into requester and acceptor positions.
- Added tests

## ⏰ 현재 버그
x

## ✏ Git Close
> close #77 
