### PR TITLE
refactor: refreshToken saving, authentication, reissue

### DIFF
--- a/src/main/java/com/gdg/Todak/common/config/WebConfig.java
+++ b/src/main/java/com/gdg/Todak/common/config/WebConfig.java
@@ -47,6 +47,9 @@ public class WebConfig implements WebMvcConfigurer {
             "/api/v1/members/logout",
             "/api/v1/members/edit",
             "/api/v1/members/edit-password",
+
+            "/api/v1/auth/reissue",
+
             "/api/v1/make/uuid",
 
             "/swagger-ui/**",

--- a/src/main/java/com/gdg/Todak/member/controller/AuthController.java
+++ b/src/main/java/com/gdg/Todak/member/controller/AuthController.java
@@ -20,7 +20,7 @@ public class AuthController {
 
     private final AuthService authService;
 
-    @PostMapping("/refresh")
+    @PostMapping("/reissue")
     @Operation(summary = "액세스 토큰 갱신", description = "리프레시 토큰이 유효하다면 액세스 토큰을 갱신한다.")
     public ApiResponse<Jwt> updateAccessTokenToken(@RequestBody UpdateAccessTokenRequest request) {
         return ApiResponse.ok(authService.updateAccessToken(request.toServiceRequest()));

--- a/src/main/java/com/gdg/Todak/member/controller/MemberController.java
+++ b/src/main/java/com/gdg/Todak/member/controller/MemberController.java
@@ -48,9 +48,8 @@ public class MemberController {
 
     @PostMapping("/logout")
     @Operation(summary = "로그아웃", description = "리프레시 토큰을 삭제하여 로그아웃한다.")
-    public ApiResponse<LogoutResponse> logout(@Parameter(hidden = true) @Login AuthenticateUser user,
-                                              @RequestBody LogoutRequest request) {
-        return ApiResponse.ok(memberService.logout(user, request.toServiceRequest()));
+    public ApiResponse<LogoutResponse> logout(@Parameter(hidden = true) @Login AuthenticateUser user) {
+        return ApiResponse.ok(memberService.logout(user));
     }
 
     @PostMapping("/me")

--- a/src/main/java/com/gdg/Todak/member/controller/request/UpdateAccessTokenRequest.java
+++ b/src/main/java/com/gdg/Todak/member/controller/request/UpdateAccessTokenRequest.java
@@ -10,16 +10,19 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class UpdateAccessTokenRequest {
 
+    private String accessToken;
     private String refreshToken;
 
     @Builder
-    public UpdateAccessTokenRequest(String refreshToken) {
+    public UpdateAccessTokenRequest(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
         this.refreshToken = refreshToken;
     }
 
     public UpdateAccessTokenServiceRequest toServiceRequest() {
         return UpdateAccessTokenServiceRequest.builder()
-                .refreshToken(refreshToken)
-                .build();
+            .accessToken(accessToken)
+            .refreshToken(refreshToken)
+            .build();
     }
 }

--- a/src/main/java/com/gdg/Todak/member/service/request/UpdateAccessTokenServiceRequest.java
+++ b/src/main/java/com/gdg/Todak/member/service/request/UpdateAccessTokenServiceRequest.java
@@ -8,10 +8,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class UpdateAccessTokenServiceRequest {
 
+    private String accessToken;
     private String refreshToken;
 
     @Builder
-    public UpdateAccessTokenServiceRequest(String refreshToken) {
+    public UpdateAccessTokenServiceRequest(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
         this.refreshToken = refreshToken;
     }
 }

--- a/src/test/java/com/gdg/Todak/member/controller/AuthControllerTest.java
+++ b/src/test/java/com/gdg/Todak/member/controller/AuthControllerTest.java
@@ -20,15 +20,17 @@ class AuthControllerTest extends ControllerTestSupport {
     @Test
     void updateRefreshTokenTest() throws Exception {
         // given
+        String accessToken = "access_token";
         String refreshToken = "refresh_token";
 
         UpdateAccessTokenRequest request = UpdateAccessTokenRequest.builder()
+                .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .build();
 
         Jwt jwt = Jwt.builder()
                 .accessToken("new_access_token")
-                .refreshToken(refreshToken)
+                .refreshToken("new_refresh_token")
                 .build();
 
         // when
@@ -36,7 +38,7 @@ class AuthControllerTest extends ControllerTestSupport {
 
         // then
         mockMvc.perform(
-                        post("/api/v1/auth/refresh")
+                        post("/api/v1/auth/reissue")
                                 .content(objectMapper.writeValueAsString(request))
                                 .contentType(MediaType.APPLICATION_JSON)
                 )

--- a/src/test/java/com/gdg/Todak/member/service/MemberServiceTest.java
+++ b/src/test/java/com/gdg/Todak/member/service/MemberServiceTest.java
@@ -125,11 +125,13 @@ class MemberServiceTest {
 
         // when
         LoginResponse loginResponse = memberService.login(request);
-        refreshToken = loginResponse.getRefreshToken();
 
         // then
-        Long memberId = Long.valueOf((String) redisTemplate.opsForValue().get(refreshToken));
-        assertThat(memberId).isNotNull();
+        assertThat(loginResponse.getAccessToken()).isNotNull();
+        assertThat(loginResponse.getAccessToken()).isNotBlank();
+
+        assertThat(loginResponse.getRefreshToken()).isNotNull();
+        assertThat(loginResponse.getRefreshToken()).isNotBlank();
     }
 
     @DisplayName("이미 존재하는 userId이면 true를 반환한다.")


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #-


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
1. 토큰 갱신 엔드포인트를 `refresh` &rarr; `reissue`로 변경하였습니다.
2. refreshToken 저장 방식을 변경하였습니다
* 기존 방식 : key=refreshToken, value=memberId
* 바뀐 방식 : key=memberId, value=refreshToken
3. reissue 방식
* accessToken과 refreshToken을 요청으로 넘겨줌
* accessToken에서 memberId 뽑아내기 (ExpiredJwtException try 처리 후 catch 구문에서 claim 및 memberId 추출)
* 요청으로 들어온 refreshToken과 redis에서 memberId로 찾은 refreshToken이 동일한지 확인
* 동일하면 새로운 accessToken과 새로운 refreshToken 발급
* 로그아웃 시 accessToken 기반으로 memberId를 알아내어 redis에서 memberId를 키로 삭제하게 처리하였습니다.

### 스크린샷 (선택)
-

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> 여러 요청 파라미터와 레디스 저장 정보등이 많이 달라지는 리펙토링이라 신경써서 작업하긴 했는데 기존 프로세스와 충돌이 나거나 로직상 빼먹거나 아니면 잘못 작성된 부분이 보이시면 바로 말씀해주세요!


## ⏰ 현재 버그
모든 테스트 통과 확인하였습니다.

## ✏ Git Close
> close #-
